### PR TITLE
Fix GetNFTShowcase endpoint iterating over burned NFTs

### DIFF
--- a/routes/nft.go
+++ b/routes/nft.go
@@ -730,7 +730,6 @@ func (fes *APIServer) GetNFTShowcase(ww http.ResponseWriter, req *http.Request) 
 		}
 
 		if postEntry.NumNFTCopiesBurned == postEntry.NumNFTCopies {
-			_AddInternalServerError(ww, fmt.Sprint("GetNFTShowcase: All copies of the NFT have been burned."))
 			continue
 		}
 


### PR DESCRIPTION
Showcase was hard-failing when it included an NFT with all copies burnt.