### PR TITLE
Give different sign-up bonus amounts based on country of ID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ COPY backend/config  config
 COPY backend/cmd     cmd
 COPY backend/miner   miner
 COPY backend/routes  routes
+COPY backend/utils   utils
 COPY backend/main.go .
 
 # include core src

--- a/routes/admin_jumio.go
+++ b/routes/admin_jumio.go
@@ -144,8 +144,6 @@ type AdminUpdateJumioUSDCentsResponse struct {
 }
 
 func (fes *APIServer) AdminUpdateJumioUSDCents(ww http.ResponseWriter, req *http.Request) {
-	//_AddBadRequestError(ww, fmt.Sprintf("AdminUpdateJumioDeSo: deprecated"))
-	//return
 	decoder := json.NewDecoder(io.LimitReader(req.Body, MaxRequestBodySizeBytes))
 	requestData := AdminUpdateJumioUSDCentsRequest{}
 	if err := decoder.Decode(&requestData); err != nil {

--- a/routes/admin_jumio.go
+++ b/routes/admin_jumio.go
@@ -158,6 +158,9 @@ func (fes *APIServer) AdminUpdateJumioUSDCents(ww http.ResponseWriter, req *http
 		return
 	}
 
+	// Update all country level sign up bonus metadata explicitly in case some are using the default amount
+	fes.SetAllCountrySignUpBonusMetadata()
+
 	res := AdminUpdateJumioUSDCentsResponse{
 		USDCents: requestData.USDCents,
 	}

--- a/routes/admin_jumio.go
+++ b/routes/admin_jumio.go
@@ -7,8 +7,10 @@ import (
 	"fmt"
 	"github.com/deso-protocol/backend/utils"
 	"github.com/deso-protocol/core/lib"
+	"github.com/golang/glog"
 	"io"
 	"net/http"
+	"strings"
 )
 
 type AdminResetJumioRequest struct {
@@ -304,5 +306,46 @@ func (fes *APIServer) AdminGetAllCountryLevelSignUpBonuses(ww http.ResponseWrite
 	if err := json.NewEncoder(ww).Encode(res); err != nil {
 		_AddBadRequestError(ww, fmt.Sprintf("GetAllCountryLevelSignUpBonuses: Encode failed: %v", err))
 		return
+	}
+}
+
+type CountrySignUpBonusResponse struct {
+	CountryLevelSignUpBonus CountryLevelSignUpBonus
+	CountryCodeDetails      utils.CountryCodeDetails
+}
+
+// SetAllCountrySignUpBonusMetadata goes through all countries in map of CountryCodes in utils and sets the sign-up
+// bonus config.
+func (fes *APIServer) SetAllCountrySignUpBonusMetadata() {
+	for countryCode, countryDetails := range utils.CountryCodes {
+		signUpBonus, err := fes.GetJumioCountrySignUpBonus(countryCode)
+		if err != nil {
+			glog.Errorf("SetAllCountrySignUpBonusMetadata: %v", err)
+			// If there was an error, look up the current value in the map and use that.
+			fes.GetSingleCountrySignUpBonus(countryCode)
+		}
+		fes.SetSingleCountrySignUpBonus(countryDetails, signUpBonus)
+	}
+}
+
+// SetSingleCountrySignUpBonus sets the sign up bonus configuration for a given country in the cached map.
+func (fes *APIServer) SetSingleCountrySignUpBonus(countryDetails utils.CountryCodeDetails,
+	signUpBonus CountryLevelSignUpBonus) {
+	fes.AllCountryLevelSignUpBonuses[countryDetails.Name] = CountrySignUpBonusResponse{
+		CountryLevelSignUpBonus: signUpBonus,
+		CountryCodeDetails:      countryDetails,
+	}
+}
+
+// GetSingleCountrySignUpBonus returns the current value of the sign-up bonus configuration stored in the cached map.
+func (fes *APIServer) GetSingleCountrySignUpBonus(countryCode string) CountryLevelSignUpBonus {
+	// Convert country code to uppercase just in case.
+	countryCodeDetails := utils.CountryCodes[strings.ToUpper(countryCode)]
+	// If we can't find the signup bonus from the map, return the default. Else, return the sign up bonus we found in
+	// the map.
+	if countrySignUpBonusResponse, exists := fes.AllCountryLevelSignUpBonuses[countryCodeDetails.Name]; !exists {
+		return fes.GetDefaultJumioCountrySignUpBonus()
+	} else {
+		return countrySignUpBonusResponse.CountryLevelSignUpBonus
 	}
 }

--- a/routes/admin_jumio.go
+++ b/routes/admin_jumio.go
@@ -160,7 +160,8 @@ func (fes *APIServer) AdminUpdateJumioUSDCents(ww http.ResponseWriter, req *http
 		return
 	}
 
-	// Update all country level sign up bonus metadata explicitly in case some are using the default amount
+	// Update the cache of all country level sign up bonus metadata explicitly in case
+	// some are using the default amount
 	fes.SetAllCountrySignUpBonusMetadata()
 
 	res := AdminUpdateJumioUSDCentsResponse{
@@ -289,7 +290,7 @@ func (fes *APIServer) AdminUpdateJumioCountrySignUpBonus(ww http.ResponseWriter,
 			"error putting country level sign up bonus metadata in global state: %v", err))
 		return
 	}
-	// Update the map
+	// Update the cache
 	fes.SetSingleCountrySignUpBonus(countryCodeDetails, requestData.CountryLevelSignUpBonus)
 }
 
@@ -315,14 +316,14 @@ type CountrySignUpBonusResponse struct {
 }
 
 // SetAllCountrySignUpBonusMetadata goes through all countries in map of CountryCodes in utils and sets the sign-up
-// bonus config.
+// bonus config in cache.
 func (fes *APIServer) SetAllCountrySignUpBonusMetadata() {
 	for countryCode, countryDetails := range utils.CountryCodes {
 		signUpBonus, err := fes.GetJumioCountrySignUpBonus(countryCode)
 		if err != nil {
 			glog.Errorf("SetAllCountrySignUpBonusMetadata: %v", err)
 			// If there was an error, look up the current value in the map and use that.
-			fes.GetSingleCountrySignUpBonus(countryCode)
+			signUpBonus = fes.GetSingleCountrySignUpBonus(countryCode)
 		}
 		fes.SetSingleCountrySignUpBonus(countryDetails, signUpBonus)
 	}

--- a/routes/base.go
+++ b/routes/base.go
@@ -276,7 +276,7 @@ type GetAppStateResponse struct {
 	BuyWithETH            bool
 
 	USDCentsPerDeSoExchangeRate uint64
-	JumioDeSoNanos              uint64
+	JumioDeSoNanos              uint64 // Deprecated
 	JumioUSDCents               uint64
 
 	DefaultFeeRateNanosPerKB uint64

--- a/routes/base.go
+++ b/routes/base.go
@@ -327,7 +327,7 @@ func (fes *APIServer) GetAppState(ww http.ResponseWriter, req *http.Request) {
 		HasJumioIntegration:                 fes.IsConfiguredForJumio(),
 		BuyWithETH:                          fes.IsConfiguredForETH(),
 		USDCentsPerDeSoExchangeRate:         fes.GetExchangeDeSoPrice(),
-		JumioDeSoNanos:                      fes.GetJumioDeSoNanos(),
+		JumioDeSoNanos:                      fes.GetJumioDeSoNanos(), // Deprecated
 		JumioUSDCents:                       fes.GetJumioUSDCents(),
 		DefaultFeeRateNanosPerKB:            defaultFeeRateNanosPerKB,
 		TransactionFeeMap:                   fes.TxnFeeMapToResponse(true),

--- a/routes/base.go
+++ b/routes/base.go
@@ -277,9 +277,10 @@ type GetAppStateResponse struct {
 
 	USDCentsPerDeSoExchangeRate uint64
 	JumioDeSoNanos              uint64
+	JumioUSDCents               uint64
 
 	DefaultFeeRateNanosPerKB uint64
-	TransactionFeeMap map[string][]TransactionFee
+	TransactionFeeMap        map[string][]TransactionFee
 
 	// Address to which we want to send ETH when used to buy DESO
 	BuyETHAddress string
@@ -312,7 +313,7 @@ func (fes *APIServer) GetAppState(ww http.ResponseWriter, req *http.Request) {
 	if globalParams != nil && globalParams.MinimumNetworkFeeNanosPerKB > 0 {
 		defaultFeeRateNanosPerKB = globalParams.MinimumNetworkFeeNanosPerKB
 	}
-	
+
 	res := &GetAppStateResponse{
 		MinSatoshisBurnedForProfileCreation: fes.Config.MinSatoshisForProfile,
 		BlockHeight:                         fes.backendServer.GetBlockchain().BlockTip().Height,
@@ -327,6 +328,7 @@ func (fes *APIServer) GetAppState(ww http.ResponseWriter, req *http.Request) {
 		BuyWithETH:                          fes.IsConfiguredForETH(),
 		USDCentsPerDeSoExchangeRate:         fes.GetExchangeDeSoPrice(),
 		JumioDeSoNanos:                      fes.GetJumioDeSoNanos(),
+		JumioUSDCents:                       fes.GetJumioUSDCents(),
 		DefaultFeeRateNanosPerKB:            defaultFeeRateNanosPerKB,
 		TransactionFeeMap:                   fes.TxnFeeMapToResponse(true),
 		BuyETHAddress:                       fes.Config.BuyDESOETHAddress,

--- a/routes/global_state.go
+++ b/routes/global_state.go
@@ -157,7 +157,7 @@ var (
 	_GlobalStatePrefixJumioDeSoNanos = []byte{21}
 
 	// Jumio USD Cents
-	_GlobalStatePrefixJumioUSDCents = []byte{38}
+	_GlobalStatePrefixJumioUSDCents = []byte{39}
 
 	// Tutorial featured well-known creators
 	_GlobalStateKeyWellKnownTutorialCreators = []byte{22}
@@ -207,14 +207,14 @@ var (
 	_GlobalStatePrefixForHotFeedPKIDMultiplierOps = []byte{36}
 
 	// This key is used to manage sign up bonus configurations for a country
-	_GlobalStatePrefixForCountryCodeToCountrySignUpBonus = []byte{37}
+	_GlobalStatePrefixForCountryCodeToCountrySignUpBonus = []byte{38}
 
 	// TODO: This process is a bit error-prone. We should come up with a test or
 	// something to at least catch cases where people have two prefixes with the
 	// same ID.
 	//
 
-	// NEXT_TAG: 39
+	// NEXT_TAG: 40
 )
 
 type HotFeedApprovedPostOp struct {

--- a/routes/global_state.go
+++ b/routes/global_state.go
@@ -147,8 +147,11 @@ var (
 
 	_GlobalStatePrefixCountryIDDocumentTypeSubTypeDocumentNumber = []byte{19}
 
-	// Jumio DeSoNanos
+	// Jumio DeSoNanos -- Deprecated!
 	_GlobalStatePrefixJumioDeSoNanos = []byte{21}
+
+	// Jumio USD Cents
+	_GlobalStatePrefixJumioUSDCents = []byte{39}
 
 	// Tutorial featured well-known creators
 	_GlobalStateKeyWellKnownTutorialCreators = []byte{22}
@@ -197,12 +200,15 @@ var (
 	// <prefix, OperationTimestampNanos, PKID> -> <HotFeedPKIDMultiplierOp>
 	_GlobalStatePrefixForHotFeedPKIDMultiplierOps = []byte{36}
 
+	// This key is used to manage sign up bonus configurations for a country
+	_GlobalStatePrefixForCountryCodeToCountrySignUpBonus = []byte{37}
+
 	// TODO: This process is a bit error-prone. We should come up with a test or
 	// something to at least catch cases where people have two prefixes with the
 	// same ID.
 	//
 
-	// NEXT_TAG: 38
+	// NEXT_TAG: 40
 )
 
 type HotFeedApprovedPostOp struct {
@@ -362,7 +368,7 @@ const (
 	INVEST_OTHERS_SELL TutorialStatus = "InvestInOthersSellComplete"
 	CREATE_PROFILE     TutorialStatus = "TutorialCreateProfileComplete"
 	INVEST_SELF        TutorialStatus = "InvestInYourselfComplete"
-	FOLLOW_CREATORS	   TutorialStatus = "FollowCreatorsComplete"
+	FOLLOW_CREATORS    TutorialStatus = "FollowCreatorsComplete"
 	DIAMOND            TutorialStatus = "GiveADiamondComplete"
 	COMPLETE           TutorialStatus = "TutorialComplete"
 )
@@ -397,6 +403,13 @@ type WyreWalletOrderMetadata struct {
 
 	// BlockHash of the transaction for sending the DeSo
 	BasicTransferTxnBlockHash *lib.BlockHash
+}
+
+type CountryLevelSignUpBonus struct {
+	AllowCustomReferralAmount      bool
+	ReferralAmountOverrideUSDCents uint64
+	AllowCustomKickbackAmount      bool
+	KickbackAmountOverrideUSDCents uint64
 }
 
 func GlobalStateKeyForNFTDropEntry(dropNumber uint64) []byte {
@@ -646,6 +659,11 @@ func GlobalStateKeyForJumioDeSoNanos() []byte {
 	return prefixCopy
 }
 
+func GlobalStateKeyForJumioUSDCents() []byte {
+	prefixCopy := append([]byte{}, _GlobalStatePrefixJumioUSDCents...)
+	return prefixCopy
+}
+
 func GlobalStateKeyWellKnownTutorialCreators(pkid *lib.PKID) []byte {
 	prefixCopy := append([]byte{}, _GlobalStateKeyWellKnownTutorialCreators...)
 	key := append(prefixCopy, pkid[:]...)
@@ -673,6 +691,12 @@ func GlobalStateKeyTransactionFeeOutputsFromTxnType(txnType lib.TxnType) []byte 
 func GlobalStateKeyExemptPublicKey(publicKey []byte) []byte {
 	prefixCopy := append([]byte{}, _GlobalStatePrefixExemptPublicKeys...)
 	key := append(prefixCopy, publicKey[:]...)
+	return key
+}
+
+func GlobalStateKeyForCountryCodeToCountrySignUpBonus(countryCode string) []byte {
+	prefixCopy := append([]byte{}, _GlobalStatePrefixForCountryCodeToCountrySignUpBonus...)
+	key := append(prefixCopy, []byte(strings.ToLower(countryCode))...)
 	return key
 }
 

--- a/routes/global_state.go
+++ b/routes/global_state.go
@@ -157,7 +157,7 @@ var (
 	_GlobalStatePrefixJumioDeSoNanos = []byte{21}
 
 	// Jumio USD Cents
-	_GlobalStatePrefixJumioUSDCents = []byte{39}
+	_GlobalStatePrefixJumioUSDCents = []byte{38}
 
 	// Tutorial featured well-known creators
 	_GlobalStateKeyWellKnownTutorialCreators = []byte{22}
@@ -214,7 +214,7 @@ var (
 	// same ID.
 	//
 
-	// NEXT_TAG: 40
+	// NEXT_TAG: 39
 )
 
 type HotFeedApprovedPostOp struct {
@@ -412,9 +412,18 @@ type WyreWalletOrderMetadata struct {
 }
 
 type CountryLevelSignUpBonus struct {
-	AllowCustomReferralAmount      bool
+	// If true, referee amount specified in referral code will be paid to users who sign up with IDs from this country.
+	// If false, ReferralAmountOverrideUSDCents will be paid to users who sign up with IDs from this country.
+	AllowCustomReferralAmount bool
+	// Amount all referees will be paid when signing up from this country if AllowCustomReferralAmount is false.
 	ReferralAmountOverrideUSDCents uint64
-	AllowCustomKickbackAmount      bool
+	// If true, referrer amount specified in referral code will be paid as a kickback to users who gave out referral
+	// code that a user signed up with IDs from this country.
+	// If false, KickbackAmountOverrideUSDCents will be paid as a kickback to referrers when a user signs up with an ID
+	// from this country.
+	AllowCustomKickbackAmount bool
+	// Amount all referrers will be paid when a referee signs up from this country if AllowCustomKickbackAmount is
+	// false.
 	KickbackAmountOverrideUSDCents uint64
 }
 

--- a/routes/global_state_test.go
+++ b/routes/global_state_test.go
@@ -22,19 +22,19 @@ func TestGlobalStateServicePutGetDeleteWithDB(t *testing.T) {
 
 	// Getting when no value is present should return nil without an
 	// error.
-	val, err := apiServer.GlobalStateGet([]byte("woo"))
+	val, err := apiServer.GlobalState.Get([]byte("woo"))
 	require.NoError(err)
 	require.Nil(val)
 
 	// Putting then getting a value should work.
-	require.NoError(apiServer.GlobalStatePut([]byte("woo"), []byte("hoo")))
-	val, err = apiServer.GlobalStateGet([]byte("woo"))
+	require.NoError(apiServer.GlobalState.Put([]byte("woo"), []byte("hoo")))
+	val, err = apiServer.GlobalState.Get([]byte("woo"))
 	require.NoError(err)
 	require.Equal(val, []byte("hoo"))
 
 	// Doing a batch get should work.
-	require.NoError(apiServer.GlobalStatePut([]byte("fan"), []byte("tastic")))
-	valueList, err := apiServer.GlobalStateBatchGet([][]byte{
+	require.NoError(apiServer.GlobalState.Put([]byte("fan"), []byte("tastic")))
+	valueList, err := apiServer.GlobalState.BatchGet([][]byte{
 		[]byte("woo"),
 		[]byte("great"),
 		[]byte("fan"),
@@ -50,8 +50,8 @@ func TestGlobalStateServicePutGetDeleteWithDB(t *testing.T) {
 	}
 
 	// Deleting a value should make it no longer gettable.
-	require.NoError(apiServer.GlobalStateDelete([]byte("woo")))
-	val, err = apiServer.GlobalStateGet([]byte("woo"))
+	require.NoError(apiServer.GlobalState.Delete([]byte("woo")))
+	val, err = apiServer.GlobalState.Get([]byte("woo"))
 	require.NoError(err)
 	require.Nil(val)
 }
@@ -67,7 +67,7 @@ func TestGlobalStateServicePutGetDeleteWithRemoteNode(t *testing.T) {
 	// Getting when no value is present should return nil without an
 	// error.
 	{
-		url, json_data, err := apiServer.CreateGlobalStateGetRequest([]byte("woo"))
+		url, json_data, err := apiServer.GlobalState.CreateGetRequest([]byte("woo"))
 		require.NoError(err)
 		request, _ := http.NewRequest(
 			"POST", url, bytes.NewBuffer(json_data))
@@ -85,7 +85,7 @@ func TestGlobalStateServicePutGetDeleteWithRemoteNode(t *testing.T) {
 
 	// Putting then getting a value should work.
 	{
-		url, json_data, err := apiServer.CreateGlobalStatePutRequest([]byte("woo"), []byte("hoo"))
+		url, json_data, err := apiServer.GlobalState.CreatePutRequest([]byte("woo"), []byte("hoo"))
 		require.NoError(err)
 		request, _ := http.NewRequest(
 			"POST", url, bytes.NewBuffer(json_data))
@@ -100,7 +100,7 @@ func TestGlobalStateServicePutGetDeleteWithRemoteNode(t *testing.T) {
 		}
 	}
 	{
-		url, json_data, err := apiServer.CreateGlobalStateGetRequest([]byte("woo"))
+		url, json_data, err := apiServer.GlobalState.CreateGetRequest([]byte("woo"))
 		require.NoError(err)
 		request, _ := http.NewRequest(
 			"POST", url,
@@ -119,7 +119,7 @@ func TestGlobalStateServicePutGetDeleteWithRemoteNode(t *testing.T) {
 
 	// Batch get should work.
 	{
-		url, json_data, err := apiServer.CreateGlobalStateBatchGetRequest(
+		url, json_data, err := apiServer.GlobalState.CreateBatchGetRequest(
 			[][]byte{[]byte("woo"), []byte("fantastic"), []byte("great")},
 		)
 		require.NoError(err)
@@ -145,7 +145,7 @@ func TestGlobalStateServicePutGetDeleteWithRemoteNode(t *testing.T) {
 
 	// Deleting a value should make it no longer gettable.
 	{
-		url, json_data, err := apiServer.CreateGlobalStateDeleteRequest([]byte("woo"))
+		url, json_data, err := apiServer.GlobalState.CreateDeleteRequest([]byte("woo"))
 		require.NoError(err)
 		request, _ := http.NewRequest(
 			"POST", url,
@@ -161,7 +161,7 @@ func TestGlobalStateServicePutGetDeleteWithRemoteNode(t *testing.T) {
 		}
 	}
 	{
-		url, json_data, err := apiServer.CreateGlobalStateGetRequest([]byte("woo"))
+		url, json_data, err := apiServer.GlobalState.CreateGetRequest([]byte("woo"))
 		require.NoError(err)
 		request, _ := http.NewRequest(
 			"POST", url,
@@ -188,19 +188,19 @@ func TestGlobalStateServiceURLCreation(t *testing.T) {
 		t, "https://deso.com:17001" /*globalStateRemoteNode*/)
 
 	{
-		url, _, err := apiServer.CreateGlobalStateGetRequest([]byte("woo"))
+		url, _, err := apiServer.GlobalState.CreateGetRequest([]byte("woo"))
 		require.NoError(err)
 		assert.Equal("https://deso.com:17001/api/v1/global-state/get?shared_secret=abcdef", url)
 	}
 
 	{
-		url, _, err := apiServer.CreateGlobalStatePutRequest([]byte("woo"), []byte("hoo"))
+		url, _, err := apiServer.GlobalState.CreatePutRequest([]byte("woo"), []byte("hoo"))
 		require.NoError(err)
 		assert.Equal("https://deso.com:17001/api/v1/global-state/put?shared_secret=abcdef", url)
 	}
 
 	{
-		url, _, err := apiServer.CreateGlobalStateBatchGetRequest(
+		url, _, err := apiServer.GlobalState.CreateBatchGetRequest(
 			[][]byte{[]byte("woo"), []byte("fantastic"), []byte("great")},
 		)
 		require.NoError(err)
@@ -208,7 +208,7 @@ func TestGlobalStateServiceURLCreation(t *testing.T) {
 	}
 
 	{
-		url, _, err := apiServer.CreateGlobalStateDeleteRequest([]byte("woo"))
+		url, _, err := apiServer.GlobalState.CreateDeleteRequest([]byte("woo"))
 		require.NoError(err)
 		assert.Equal("https://deso.com:17001/api/v1/global-state/delete?shared_secret=abcdef", url)
 	}

--- a/routes/server.go
+++ b/routes/server.go
@@ -344,7 +344,7 @@ type APIServer struct {
 	TotalSupplyDESO  float64
 	RichList         []RichListEntryResponse
 
-  // map of country name to sign up bonus data
+	// map of country name to sign up bonus data
 	AllCountryLevelSignUpBonuses map[string]CountrySignUpBonusResponse
 
 	// Signals that the frontend server is in a stopped state

--- a/routes/server.go
+++ b/routes/server.go
@@ -388,8 +388,9 @@ func NewAPIServer(
 		PublicKeyBase58Prefix:     publicKeyBase58Prefix,
 		// We consider last trade prices from the last hour when determining the current price of DeSo.
 		// This helps prevents attacks that attempt to purchase $DESO at below market value.
-		LastTradePriceLookback: uint64(time.Hour.Nanoseconds()),
-		quit:                   make(chan struct{}),
+		LastTradePriceLookback:       uint64(time.Hour.Nanoseconds()),
+		AllCountryLevelSignUpBonuses: make(map[string]CountrySignUpBonusResponse),
+		quit:                         make(chan struct{}),
 	}
 
 	fes.StartSeedBalancesMonitoring()

--- a/routes/server.go
+++ b/routes/server.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	fmt "fmt"
-	"github.com/deso-protocol/backend/utils"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -2048,47 +2047,6 @@ func (fes *APIServer) SetGlobalFeedPostHashes() {
 		glog.Errorf("SetGlobalFeedPostHashes: Error getting global feed post hashes: %v", err)
 	} else {
 		fes.GlobalFeedPostHashes = postHashes
-	}
-}
-
-type CountrySignUpBonusResponse struct {
-	CountryLevelSignUpBonus CountryLevelSignUpBonus
-	CountryCodeDetails      utils.CountryCodeDetails
-}
-
-// SetAllCountrySignUpBonusMetadata goes through all countries in map of CountryCodes in utils and sets the sign-up
-// bonus config.
-func (fes *APIServer) SetAllCountrySignUpBonusMetadata() {
-	for countryCode, countryDetails := range utils.CountryCodes {
-		signUpBonus, err := fes.GetJumioCountrySignUpBonus(countryCode)
-		if err != nil {
-			glog.Errorf("SetAllCountrySignUpBonusMetadata: %v", err)
-			// If there was an error, look up the current value in the map and use that.
-			fes.GetSingleCountrySignUpBonus(countryCode)
-		}
-		fes.SetSingleCountrySignUpBonus(countryDetails, signUpBonus)
-	}
-}
-
-// SetSingleCountrySignUpBonus sets the sign up bonus configuration for a given country in the cached map.
-func (fes *APIServer) SetSingleCountrySignUpBonus(countryDetails utils.CountryCodeDetails,
-	signUpBonus CountryLevelSignUpBonus) {
-	fes.AllCountryLevelSignUpBonuses[countryDetails.Name] = CountrySignUpBonusResponse{
-		CountryLevelSignUpBonus: signUpBonus,
-		CountryCodeDetails:      countryDetails,
-	}
-}
-
-// GetSingleCountrySignUpBonus returns the current value of the sign-up bonus configuration stored in the cached map.
-func (fes *APIServer) GetSingleCountrySignUpBonus(countryCode string) CountryLevelSignUpBonus {
-	// Convert country code to uppercase just in case.
-	countryCodeDetails := utils.CountryCodes[strings.ToUpper(countryCode)]
-	// If we can't find the signup bonus from the map, return the default. Else, return the sign up bonus we found in
-	// the map.
-	if countrySignUpBonusResponse, exists := fes.AllCountryLevelSignUpBonuses[countryCodeDetails.Name]; !exists {
-		return fes.GetDefaultJumioCountrySignUpBonus()
-	} else {
-		return countrySignUpBonusResponse.CountryLevelSignUpBonus
 	}
 }
 

--- a/routes/server.go
+++ b/routes/server.go
@@ -2056,6 +2056,8 @@ type CountrySignUpBonusResponse struct {
 	CountryCodeDetails      utils.CountryCodeDetails
 }
 
+// SetAllCountrySignUpBonusMetadata goes through all countries in map of CountryCodes in utils and sets the sign-up
+// bonus config.
 func (fes *APIServer) SetAllCountrySignUpBonusMetadata() {
 	for countryCode, countryDetails := range utils.CountryCodes {
 		signUpBonus, err := fes.GetJumioCountrySignUpBonus(countryCode)
@@ -2068,6 +2070,7 @@ func (fes *APIServer) SetAllCountrySignUpBonusMetadata() {
 	}
 }
 
+// SetSingleCountrySignUpBonus sets the sign up bonus configuration for a given country in the cached map.
 func (fes *APIServer) SetSingleCountrySignUpBonus(countryDetails utils.CountryCodeDetails,
 	signUpBonus CountryLevelSignUpBonus) {
 	fes.AllCountryLevelSignUpBonuses[countryDetails.Name] = CountrySignUpBonusResponse{
@@ -2076,8 +2079,12 @@ func (fes *APIServer) SetSingleCountrySignUpBonus(countryDetails utils.CountryCo
 	}
 }
 
+// GetSingleCountrySignUpBonus returns the current value of the sign-up bonus configuration stored in the cached map.
 func (fes *APIServer) GetSingleCountrySignUpBonus(countryCode string) CountryLevelSignUpBonus {
-	countryCodeDetails := utils.CountryCodes[countryCode]
+	// Convert country code to uppercase just in case.
+	countryCodeDetails := utils.CountryCodes[strings.ToUpper(countryCode)]
+	// If we can't find the signup bonus from the map, return the default. Else, return the sign up bonus we found in
+	// the map.
 	if countrySignUpBonusResponse, exists := fes.AllCountryLevelSignUpBonuses[countryCodeDetails.Name]; !exists {
 		return fes.GetDefaultJumioCountrySignUpBonus()
 	} else {

--- a/routes/verify.go
+++ b/routes/verify.go
@@ -735,7 +735,7 @@ func (fes *APIServer) JumioCallback(ww http.ResponseWriter, req *http.Request) {
 	idCountry := req.PostFormValue("idCountry")
 
 	// Temporarily, we will glog the idCountry to make sure the value we are getting from Jumio matches expectation.
-	glog.Infof("JumioCallback: idCountry: %v", idCountry)
+	glog.Infof("JumioCallback: idCountry: %s", idCountry)
 
 	// Identifier on ID - e.g. Driver's license number for DRIVING_LICENSE, Passport number for PASSPORT
 	idNumber := req.PostFormValue("idNumber")

--- a/routes/verify.go
+++ b/routes/verify.go
@@ -875,15 +875,19 @@ func (fes *APIServer) JumioCallback(ww http.ResponseWriter, req *http.Request) {
 	}
 }
 
+// GetDefaultJumioCountrySignUpBonus returns the default sign-up bonus configuration.
 func (fes *APIServer) GetDefaultJumioCountrySignUpBonus() CountryLevelSignUpBonus {
 	return CountryLevelSignUpBonus{
 		AllowCustomKickbackAmount:      false,
-		AllowCustomReferralAmount:      false, // Do we perhaps want this to be true?
+		AllowCustomReferralAmount:      false,
 		ReferralAmountOverrideUSDCents: fes.GetJumioUSDCents(),
 		KickbackAmountOverrideUSDCents: 0,
 	}
 }
 
+// GetJumioCountrySignUpBonus gets the country level sign up bonus configuration for the provided country code.  If
+// there is an error or there is no sign up bonus configuration for a given country, return the default sign-up bonus
+// configuration.
 func (fes *APIServer) GetJumioCountrySignUpBonus(countryCode string) (_signUpBonus CountryLevelSignUpBonus, _err error) {
 	key := GlobalStateKeyForCountryCodeToCountrySignUpBonus(countryCode)
 
@@ -909,6 +913,8 @@ func (fes *APIServer) GetJumioCountrySignUpBonus(countryCode string) (_signUpBon
 	}
 }
 
+// GetRefereeSignUpBonusAmount gets the amount the referee should get a sign-up bonus for verifying with Jumio based on
+// the country of their ID.
 func (fes *APIServer) GetRefereeSignUpBonusAmount(signUpBonus CountryLevelSignUpBonus, referralCodeUSDCents uint64) uint64 {
 	amount := signUpBonus.ReferralAmountOverrideUSDCents
 	if signUpBonus.AllowCustomReferralAmount && referralCodeUSDCents > amount {
@@ -917,6 +923,8 @@ func (fes *APIServer) GetRefereeSignUpBonusAmount(signUpBonus CountryLevelSignUp
 	return fes.GetNanosFromUSDCents(float64(amount), 0)
 }
 
+// GetReferrerSignUpBonusAmount gets the amount the referrer should get as a kickback for referring the user based
+// on the country from which the referee signed up.
 func (fes *APIServer) GetReferrerSignUpBonusAmount(signUpBonus CountryLevelSignUpBonus, referralCodeUSDCents uint64) uint64 {
 	amount := signUpBonus.KickbackAmountOverrideUSDCents
 	if signUpBonus.AllowCustomReferralAmount && referralCodeUSDCents > amount {
@@ -1066,6 +1074,7 @@ func (fes *APIServer) JumioVerifiedHandler(userMetadata *UserMetadata, jumioTran
 	return userMetadata, nil
 }
 
+// Get JumioUSDCents returns the default amount a user receives for verifying with Jumio without a referral code.
 func (fes *APIServer) GetJumioUSDCents() uint64 {
 	val, err := fes.GlobalState.Get(GlobalStateKeyForJumioUSDCents())
 	if err != nil {

--- a/routes/verify.go
+++ b/routes/verify.go
@@ -702,6 +702,15 @@ type JumioIdentityVerification struct {
 	Reason     string `json:"reason"`
 }
 
+type JumioRejectReason struct {
+	RejectReasonCode        string `json:"rejectReasonCode"`
+	RejectReasonDescription string `json:"rejectReasonDescription"`
+	RejectReasonDetails     struct {
+		DetailsCode        string `json:"detailsCode"`
+		DetailsDescription string `json:"detailsDescription"`
+	} `json:"rejectReasonDetails"`
+}
+
 // Jumio webhook - If Jumio verified user is a human that we haven't paid already, pay them some starter DESO.
 // Make sure you only allow access to jumio IPs for this endpoint, otherwise anybody can take all the funds from
 // the public key that sends DeSo. WHITELIST JUMIO IPs.
@@ -733,6 +742,9 @@ func (fes *APIServer) JumioCallback(ww http.ResponseWriter, req *http.Request) {
 
 	// Jumio TransactionID
 	jumioTransactionId := req.PostFormValue("jumioIdScanReference")
+
+	// Verification status
+	verificationStatus := req.FormValue("verificationStatus")
 
 	// Get Public key bytes and PKID
 	if userReference == "" {
@@ -776,6 +788,20 @@ func (fes *APIServer) JumioCallback(ww http.ResponseWriter, req *http.Request) {
 	// Map of data for amplitude
 	eventDataMap := make(map[string]interface{})
 	eventDataMap["referralCode"] = userMetadata.ReferralHashBase58Check
+	eventDataMap["verificationStatus"] = verificationStatus
+
+	// If verification status is DENIED_FRAUD or ERROR_NOT_READABLE_ID, parse the rejection reason
+	// See description of rejectReason here:
+	// https://github.com/Jumio/implementation-guides/blob/master/netverify/callback.md#parameters
+	if verificationStatus == "DENIED_FRAUD" || verificationStatus == "ERROR_NOT_READABLE_ID" {
+		rejectReason := req.FormValue("rejectReason")
+		var jumioRejectReason JumioRejectReason
+		if err = json.Unmarshal([]byte(rejectReason), &jumioRejectReason); err != nil {
+			glog.Errorf("JumioCallback: error unmarshaling reject reason: %v", err)
+		} else {
+			eventDataMap["rejectReason"] = jumioRejectReason
+		}
+	}
 
 	if req.FormValue("idScanStatus") != "SUCCESS" {
 		if err = fes.logAmplitudeEvent(userReference, "jumio : callback : scan : fail", eventDataMap); err != nil {
@@ -830,7 +856,7 @@ func (fes *APIServer) JumioCallback(ww http.ResponseWriter, req *http.Request) {
 		if err = fes.logAmplitudeEvent(userReference, "jumio : callback : verified", eventDataMap); err != nil {
 			glog.Errorf("JumioCallback: Error logging successful verification in amplitude: %v", err)
 		}
-		userMetadata, err = fes.JumioVerifiedHandler(userMetadata, jumioTransactionId, publicKeyBytes, utxoView)
+		userMetadata, err = fes.JumioVerifiedHandler(userMetadata, jumioTransactionId, idCountry, publicKeyBytes, utxoView)
 		if err != nil {
 			glog.Errorf("JumioCallback: Error in JumioVerifiedHandler: %v", err)
 		}
@@ -849,7 +875,58 @@ func (fes *APIServer) JumioCallback(ww http.ResponseWriter, req *http.Request) {
 	}
 }
 
-func (fes *APIServer) JumioVerifiedHandler(userMetadata *UserMetadata, jumioTransactionId string, publicKeyBytes []byte, utxoView *lib.UtxoView) (_userMetadata *UserMetadata, err error) {
+func (fes *APIServer) GetDefaultJumioCountrySignUpBonus() CountryLevelSignUpBonus {
+	return CountryLevelSignUpBonus{
+		AllowCustomKickbackAmount:      false,
+		AllowCustomReferralAmount:      false, // Do we perhaps want this to be true?
+		ReferralAmountOverrideUSDCents: fes.GetJumioUSDCents(),
+		KickbackAmountOverrideUSDCents: 0,
+	}
+}
+
+func (fes *APIServer) GetJumioCountrySignUpBonus(countryCode string) (_signUpBonus CountryLevelSignUpBonus, _err error) {
+	key := GlobalStateKeyForCountryCodeToCountrySignUpBonus(countryCode)
+
+	jumioCountrySignUpBonusMetadataBytes, err := fes.GlobalStateGet(key)
+	if err != nil {
+		return fes.GetDefaultJumioCountrySignUpBonus(), fmt.Errorf(
+			"GetJumioCountrySignUpBonus: error getting sign up bonus metadata from global state for %s: %v",
+			countryCode, err)
+	}
+	var signUpBonus CountryLevelSignUpBonus
+
+	if jumioCountrySignUpBonusMetadataBytes != nil {
+		if err = gob.NewDecoder(bytes.NewReader(jumioCountrySignUpBonusMetadataBytes)).Decode(
+			&signUpBonus); err != nil {
+			return fes.GetDefaultJumioCountrySignUpBonus(), fmt.Errorf(
+				"GetJumioCountrySignUpBonus: Failed decoding signup bonus metadata (%s): %v",
+				countryCode, err)
+		}
+		return signUpBonus, nil
+	} else {
+		// We were unable to find a country, return the default
+		return fes.GetDefaultJumioCountrySignUpBonus(), nil
+	}
+}
+
+func (fes *APIServer) GetRefereeSignUpBonusAmount(signUpBonus CountryLevelSignUpBonus, referralCodeUSDCents uint64) uint64 {
+	amount := signUpBonus.ReferralAmountOverrideUSDCents
+	if signUpBonus.AllowCustomReferralAmount && referralCodeUSDCents > amount {
+		amount = referralCodeUSDCents
+	}
+	return fes.GetNanosFromUSDCents(float64(amount), 0)
+}
+
+func (fes *APIServer) GetReferrerSignUpBonusAmount(signUpBonus CountryLevelSignUpBonus, referralCodeUSDCents uint64) uint64 {
+	amount := signUpBonus.KickbackAmountOverrideUSDCents
+	if signUpBonus.AllowCustomReferralAmount && referralCodeUSDCents > amount {
+		amount = referralCodeUSDCents
+	}
+	return fes.GetNanosFromUSDCents(float64(amount), 0)
+}
+
+func (fes *APIServer) JumioVerifiedHandler(userMetadata *UserMetadata, jumioTransactionId string,
+	jumioCountryCode string, publicKeyBytes []byte, utxoView *lib.UtxoView) (_userMetadata *UserMetadata, err error) {
 	// Update the user metadata to show that user has been jumio verified and store jumio transaction id.
 	userMetadata.JumioVerified = true
 	userMetadata.JumioTransactionID = jumioTransactionId
@@ -857,10 +934,14 @@ func (fes *APIServer) JumioVerifiedHandler(userMetadata *UserMetadata, jumioTran
 	userMetadata.MustCompleteTutorial = true
 	userMetadata.RedoJumio = false
 
+	// We will always get a valid signUpBonusMetadataObject, so glog the error and proceed.
+	signUpBonusMetadata := fes.GetSingleCountrySignUpBonus(jumioCountryCode)
+
 	// Decide whether or not the user is going to get paid.
-	if desoNanos := fes.GetJumioDeSoNanos(); desoNanos > 0 || userMetadata.ReferralHashBase58Check != "" {
+	if signUpBonusMetadata.ReferralAmountOverrideUSDCents > 0 || userMetadata.ReferralHashBase58Check != "" {
 		payReferrer := false
 
+		referralAmountUSDCents := uint64(0)
 		// Decide whether the user should be paid the standard amount or a special referral amount.
 		if userMetadata.ReferralHashBase58Check != "" {
 			var referralInfo *ReferralInfo
@@ -868,16 +949,18 @@ func (fes *APIServer) JumioVerifiedHandler(userMetadata *UserMetadata, jumioTran
 			if err != nil {
 				glog.Errorf("JumioVerifiedHandler: Error getting referral info: %v", err)
 			} else if referralInfo != nil && (referralInfo.TotalReferrals < referralInfo.MaxReferrals || referralInfo.MaxReferrals == 0) && fes.getReferralHashStatus(referralInfo.ReferrerPKID, referralInfo.ReferralHashBase58) {
-				desoNanos = fes.GetNanosFromUSDCents(float64(referralInfo.RefereeAmountUSDCents), 0)
+				referralAmountUSDCents = referralInfo.RefereeAmountUSDCents
 				payReferrer = true
 			}
 		}
 
+		refereeSignUpBonusDeSoNanos := fes.GetRefereeSignUpBonusAmount(signUpBonusMetadata, referralAmountUSDCents)
+
 		// Pay the referee.
-		if desoNanos > 0 {
+		if refereeSignUpBonusDeSoNanos > 0 {
 			// Check the balance of the starter deso seed.
 			var balanceInsufficient bool
-			balanceInsufficient, err = fes.ExceedsDeSoBalance(desoNanos, fes.Config.StarterDESOSeed)
+			balanceInsufficient, err = fes.ExceedsDeSoBalance(refereeSignUpBonusDeSoNanos, fes.Config.StarterDESOSeed)
 			if err != nil {
 				return userMetadata, fmt.Errorf("JumioVerifiedHandler: Error checking if send deso balance is sufficient: %v", err)
 			}
@@ -886,14 +969,14 @@ func (fes *APIServer) JumioVerifiedHandler(userMetadata *UserMetadata, jumioTran
 			}
 			// Send JumioDeSoNanos to public key
 			var txnHash *lib.BlockHash
-			txnHash, err = fes.SendSeedDeSo(publicKeyBytes, desoNanos, false)
+			txnHash, err = fes.SendSeedDeSo(publicKeyBytes, refereeSignUpBonusDeSoNanos, false)
 			if err != nil {
 				return userMetadata, fmt.Errorf("JumioVerifiedHandler: Error sending starter DeSo: %v", err)
 			}
 
 			// Log payout to referee in amplitude
 			eventDataMap := make(map[string]interface{})
-			eventDataMap["amountNanos"] = desoNanos
+			eventDataMap["amountNanos"] = refereeSignUpBonusDeSoNanos
 			eventDataMap["txnHashHex"] = txnHash.String()
 			eventDataMap["referralCode"] = userMetadata.ReferralHashBase58Check
 			if err = fes.logAmplitudeEvent(lib.PkToString(publicKeyBytes, fes.Params), "referral : payout : referee", eventDataMap); err != nil {
@@ -913,6 +996,9 @@ func (fes *APIServer) JumioVerifiedHandler(userMetadata *UserMetadata, jumioTran
 			if err != nil {
 				return userMetadata, fmt.Errorf("JumioVerifiedHandler: Error getting referral info: %v", err)
 			}
+
+			kickbackAmountDeSoNanos := fes.GetReferrerSignUpBonusAmount(signUpBonusMetadata,
+				referralInfo.ReferrerAmountUSDCents)
 			// Add an index for logging all the PKIDs referred by a single PKID+ReferralHash pair.
 			refereePKID := utxoView.GetPKIDForPublicKey(publicKeyBytes)
 			pkidReferralHashRefereePKIDKey := GlobalStateKeyForPKIDReferralHashRefereePKID(referralInfo.ReferrerPKID, []byte(referralInfo.ReferralHashBase58), refereePKID.PKID)
@@ -927,14 +1013,12 @@ func (fes *APIServer) JumioVerifiedHandler(userMetadata *UserMetadata, jumioTran
 				glog.Errorf("JumioVerifiedHandler: Error adding to the index of users who were referred by a given referral code")
 			}
 
-			// Calculate how much to pay the referrer
-			referrerDeSoNanos := fes.GetNanosFromUSDCents(float64(referralInfo.ReferrerAmountUSDCents), 0)
 			if referralInfo.TotalReferrals >= referralInfo.MaxReferrals && referralInfo.MaxReferrals > 0 {
 				return userMetadata, nil
 			}
 			// Check the balance of the starter deso seed compared to the referrer deso nanos.
 			var balanceInsufficientForReferrer bool
-			balanceInsufficientForReferrer, err = fes.ExceedsDeSoBalance(referrerDeSoNanos, fes.Config.StarterDESOSeed)
+			balanceInsufficientForReferrer, err = fes.ExceedsDeSoBalance(kickbackAmountDeSoNanos, fes.Config.StarterDESOSeed)
 			if err != nil {
 				return userMetadata, fmt.Errorf("JumioVerifiedHandler: Error checking if send deso balance is sufficient: %v", err)
 			}
@@ -947,26 +1031,26 @@ func (fes *APIServer) JumioVerifiedHandler(userMetadata *UserMetadata, jumioTran
 			// Increment JumioSuccesses, TotalReferrals and add to TotralRefereeDeSoNanos and TotalReferrerDeSoNanos
 			referralInfo.NumJumioSuccesses++
 			referralInfo.TotalReferrals++
-			referralInfo.TotalRefereeDeSoNanos += desoNanos
-			referralInfo.TotalReferrerDeSoNanos += referrerDeSoNanos
+			referralInfo.TotalRefereeDeSoNanos += refereeSignUpBonusDeSoNanos
+			referralInfo.TotalReferrerDeSoNanos += kickbackAmountDeSoNanos
 
 			// Update the referral info in global state.
 			if err = fes.putReferralHashWithInfo(userMetadata.ReferralHashBase58Check, referralInfo); err != nil {
 				return userMetadata, fmt.Errorf("JumioVerifiedHandler: Error updating referral info. Skipping paying referrer: %v", err)
 			}
-			// Bail if there referrer gets nothing
-			if referrerDeSoNanos == 0 {
+			// Check that we actually have to pay the referrer before proceeding
+			if kickbackAmountDeSoNanos == 0 {
 				return userMetadata, nil
 			}
 			// Send the referrer money
 			var referrerTxnHash *lib.BlockHash
-			referrerTxnHash, err = fes.SendSeedDeSo(referrerPublicKeyBytes, referrerDeSoNanos, false)
+			referrerTxnHash, err = fes.SendSeedDeSo(referrerPublicKeyBytes, kickbackAmountDeSoNanos, false)
 			if err != nil {
 				return userMetadata, fmt.Errorf("JumioVerifiedHandler: Error sending DESO to referrer: %v", err)
 			}
 			// Log payout to referee in amplitude
 			eventDataMap := make(map[string]interface{})
-			eventDataMap["amountNanos"] = referrerDeSoNanos
+			eventDataMap["amountNanos"] = kickbackAmountDeSoNanos
 			eventDataMap["txnHashHex"] = referrerTxnHash.String()
 			eventDataMap["referralCode"] = userMetadata.ReferralHashBase58Check
 			eventDataMap["refereePublicKey"] = lib.PkToString(publicKeyBytes, fes.Params)
@@ -982,16 +1066,20 @@ func (fes *APIServer) JumioVerifiedHandler(userMetadata *UserMetadata, jumioTran
 	return userMetadata, nil
 }
 
-func (fes *APIServer) GetJumioDeSoNanos() uint64 {
-	val, err := fes.GlobalStateGet(GlobalStateKeyForJumioDeSoNanos())
+func (fes *APIServer) GetJumioUSDCents() uint64 {
+	val, err := fes.GlobalStateGet(GlobalStateKeyForJumioUSDCents())
 	if err != nil {
 		return 0
 	}
-	jumioDeSoNanos, bytesRead := lib.Uvarint(val)
+	jumioUSDCents, bytesRead := lib.Uvarint(val)
 	if bytesRead <= 0 {
 		return 0
 	}
-	return jumioDeSoNanos
+	return jumioUSDCents
+}
+
+func (fes *APIServer) GetJumioDeSoNanos() uint64 {
+	return fes.GetNanosFromUSDCents(float64(fes.GetJumioUSDCents()), 0)
 }
 
 type GetJumioStatusForPublicKeyRequest struct {

--- a/routes/verify.go
+++ b/routes/verify.go
@@ -734,6 +734,9 @@ func (fes *APIServer) JumioCallback(ww http.ResponseWriter, req *http.Request) {
 	// Country of ID
 	idCountry := req.PostFormValue("idCountry")
 
+	// Temporarily, we will glog the idCountry to make sure the value we are getting from Jumio matches expectation.
+	glog.Infof("JumioCallback: idCountry: %v", idCountry)
+
 	// Identifier on ID - e.g. Driver's license number for DRIVING_LICENSE, Passport number for PASSPORT
 	idNumber := req.PostFormValue("idNumber")
 

--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -20,6 +20,7 @@ COPY backend/apis    apis
 COPY backend/cmd     cmd
 COPY backend/miner   miner
 COPY backend/routes  routes
+COPY backend/utils   utils
 COPY backend/main.go .
 
 # include core src

--- a/utils/iso-3166-1-alpha-3-codes.go
+++ b/utils/iso-3166-1-alpha-3-codes.go
@@ -1,0 +1,1255 @@
+package utils
+
+type CountryCodeDetails struct {
+	CountryCode string
+	Name        string
+	Alpha3      string
+}
+
+var CountryCodes = map[string]CountryCodeDetails{
+	"DZA": {
+		Alpha3:      "DZA",
+		Name:        "Algeria",
+		CountryCode: "012",
+	},
+	"AGO": {
+		Alpha3:      "AGO",
+		Name:        "Angola",
+		CountryCode: "024",
+	},
+	"EGY": {
+		Alpha3:      "EGY",
+		Name:        "Egypt",
+		CountryCode: "818",
+	},
+	"BGD": {
+		Alpha3:      "BGD",
+		Name:        "Bangladesh",
+		CountryCode: "050",
+	},
+	"LIE": {
+		Alpha3:      "LIE",
+		Name:        "Liechtenstein",
+		CountryCode: "438",
+	},
+	"SOM": {
+		Alpha3:      "SOM",
+		Name:        "Somalia",
+		CountryCode: "706",
+	},
+	"NAM": {
+		Alpha3:      "NAM",
+		Name:        "Namibia",
+		CountryCode: "516",
+	},
+	"BGR": {
+		Alpha3:      "BGR",
+		Name:        "Bulgaria",
+		CountryCode: "100",
+	},
+	"BOL": {
+		Alpha3:      "BOL",
+		Name:        "Bolivia (Plurinational State of)",
+		CountryCode: "068",
+	},
+	"GHA": {
+		Alpha3:      "GHA",
+		Name:        "Ghana",
+		CountryCode: "288",
+	},
+	"CCK": {
+		Alpha3:      "CCK",
+		Name:        "Cocos (Keeling) Islands",
+		CountryCode: "166",
+	},
+	"PAK": {
+		Alpha3:      "PAK",
+		Name:        "Pakistan",
+		CountryCode: "586",
+	},
+	"CPV": {
+		Alpha3:      "CPV",
+		Name:        "Cabo Verde",
+		CountryCode: "132",
+	},
+	"JOR": {
+		Alpha3:      "JOR",
+		Name:        "Jordan",
+		CountryCode: "400",
+	},
+	"LBR": {
+		Alpha3:      "LBR",
+		Name:        "Liberia",
+		CountryCode: "430",
+	},
+	"LBY": {
+		Alpha3:      "LBY",
+		Name:        "Libya",
+		CountryCode: "434",
+	},
+	"MYS": {
+		Alpha3:      "MYS",
+		Name:        "Malaysia",
+		CountryCode: "458",
+	},
+	"IOT": {
+		Alpha3:      "IOT",
+		Name:        "British Indian Ocean Territory",
+		CountryCode: "086",
+	},
+	"PRI": {
+		Alpha3:      "PRI",
+		Name:        "Puerto Rico",
+		CountryCode: "630",
+	},
+	"MYT": {
+		Alpha3:      "MYT",
+		Name:        "Mayotte",
+		CountryCode: "175",
+	},
+	"PRK": {
+		Alpha3:      "PRK",
+		Name:        "Korea (Democratic People's Republic of)",
+		CountryCode: "408",
+	},
+	"TZA": {
+		Alpha3:      "TZA",
+		Name:        "Tanzania, United Republic of",
+		CountryCode: "834",
+	},
+	"BWA": {
+		Alpha3:      "BWA",
+		Name:        "Botswana",
+		CountryCode: "072",
+	},
+	"KHM": {
+		Alpha3:      "KHM",
+		Name:        "Cambodia",
+		CountryCode: "116",
+	},
+	"PRY": {
+		Alpha3:      "PRY",
+		Name:        "Paraguay",
+		CountryCode: "600",
+	},
+	"HKG": {
+		Alpha3:      "HKG",
+		Name:        "Hong Kong",
+		CountryCode: "344",
+	},
+	"SAU": {
+		Alpha3:      "SAU",
+		Name:        "Saudi Arabia",
+		CountryCode: "682",
+	},
+	"LBN": {
+		Alpha3:      "LBN",
+		Name:        "Lebanon",
+		CountryCode: "422",
+	},
+	"SVN": {
+		Alpha3:      "SVN",
+		Name:        "Slovenia",
+		CountryCode: "705",
+	},
+	"BFA": {
+		Alpha3:      "BFA",
+		Name:        "Burkina Faso",
+		CountryCode: "854",
+	},
+	"SVK": {
+		Alpha3:      "SVK",
+		Name:        "Slovakia",
+		CountryCode: "703",
+	},
+	"MRT": {
+		Alpha3:      "MRT",
+		Name:        "Mauritania",
+		CountryCode: "478",
+	},
+	"HRV": {
+		Alpha3:      "HRV",
+		Name:        "Croatia",
+		CountryCode: "191",
+	},
+	"CHL": {
+		Alpha3:      "CHL",
+		Name:        "Chile",
+		CountryCode: "152",
+	},
+	"CHN": {
+		Alpha3:      "CHN",
+		Name:        "China",
+		CountryCode: "156",
+	},
+	"KNA": {
+		Alpha3:      "KNA",
+		Name:        "Saint Kitts and Nevis",
+		CountryCode: "659",
+	},
+	"JAM": {
+		Alpha3:      "JAM",
+		Name:        "Jamaica",
+		CountryCode: "388",
+	},
+	"GIB": {
+		Alpha3:      "GIB",
+		Name:        "Gibraltar",
+		CountryCode: "292",
+	},
+	"DJI": {
+		Alpha3:      "DJI",
+		Name:        "Djibouti",
+		CountryCode: "262",
+	},
+	"GIN": {
+		Alpha3:      "GIN",
+		Name:        "Guinea",
+		CountryCode: "324",
+	},
+	"REU": {
+		Alpha3:      "REU",
+		Name:        "Réunion",
+		CountryCode: "638",
+	},
+	"FIN": {
+		Alpha3:      "FIN",
+		Name:        "Finland",
+		CountryCode: "246",
+	},
+	"URY": {
+		Alpha3:      "URY",
+		Name:        "Uruguay",
+		CountryCode: "858",
+	},
+	"VAT": {
+		Alpha3:      "VAT",
+		Name:        "Holy See",
+		CountryCode: "336",
+	},
+	"SYC": {
+		Alpha3:      "SYC",
+		Name:        "Seychelles",
+		CountryCode: "690",
+	},
+	"NPL": {
+		Alpha3:      "NPL",
+		Name:        "Nepal",
+		CountryCode: "524",
+	},
+	"CXR": {
+		Alpha3:      "CXR",
+		Name:        "Christmas Island",
+		CountryCode: "162",
+	},
+	"MAR": {
+		Alpha3:      "MAR",
+		Name:        "Morocco",
+		CountryCode: "504",
+	},
+	"YEM": {
+		Alpha3:      "YEM",
+		Name:        "Yemen",
+		CountryCode: "887",
+	},
+	"BVT": {
+		Alpha3:      "BVT",
+		Name:        "Bouvet Island",
+		CountryCode: "074",
+	},
+	"ZAF": {
+		Alpha3:      "ZAF",
+		Name:        "South Africa",
+		CountryCode: "710",
+	},
+	"KIR": {
+		Alpha3:      "KIR",
+		Name:        "Kiribati",
+		CountryCode: "296",
+	},
+	"PHL": {
+		Alpha3:      "PHL",
+		Name:        "Philippines",
+		CountryCode: "608",
+	},
+	"MNE": {
+		Alpha3:      "MNE",
+		Name:        "Montenegro",
+		CountryCode: "499",
+	},
+	"VIR": {
+		Alpha3:      "VIR",
+		Name:        "Virgin Islands (U.S.)",
+		CountryCode: "850",
+	},
+	"SYR": {
+		Alpha3:      "SYR",
+		Name:        "Syrian Arab Republic",
+		CountryCode: "760",
+	},
+	"MAC": {
+		Alpha3:      "MAC",
+		Name:        "Macao",
+		CountryCode: "446",
+	},
+	"NIC": {
+		Alpha3:      "NIC",
+		Name:        "Nicaragua",
+		CountryCode: "558",
+	},
+	"KAZ": {
+		Alpha3:      "KAZ",
+		Name:        "Kazakhstan",
+		CountryCode: "398",
+	},
+	"MNG": {
+		Alpha3:      "MNG",
+		Name:        "Mongolia",
+		CountryCode: "496",
+	},
+	"PYF": {
+		Alpha3:      "PYF",
+		Name:        "French Polynesia",
+		CountryCode: "258",
+	},
+	"NIU": {
+		Alpha3:      "NIU",
+		Name:        "Niue",
+		CountryCode: "570",
+	},
+	"IRL": {
+		Alpha3:      "IRL",
+		Name:        "Ireland",
+		CountryCode: "372",
+	},
+	"DMA": {
+		Alpha3:      "DMA",
+		Name:        "Dominica",
+		CountryCode: "212",
+	},
+	"BEN": {
+		Alpha3:      "BEN",
+		Name:        "Benin",
+		CountryCode: "204",
+	},
+	"GUF": {
+		Alpha3:      "GUF",
+		Name:        "French Guiana",
+		CountryCode: "254",
+	},
+	"BEL": {
+		Alpha3:      "BEL",
+		Name:        "Belgium",
+		CountryCode: "056",
+	},
+	"DEU": {
+		Alpha3:      "DEU",
+		Name:        "Germany",
+		CountryCode: "276",
+	},
+	"GUM": {
+		Alpha3:      "GUM",
+		Name:        "Guam",
+		CountryCode: "316",
+	},
+	"LKA": {
+		Alpha3:      "LKA",
+		Name:        "Sri Lanka",
+		CountryCode: "144",
+	},
+	"FLK": {
+		Alpha3:      "FLK",
+		Name:        "Falkland Islands (Malvinas)",
+		CountryCode: "238",
+	},
+	"GBR": {
+		Alpha3:      "GBR",
+		Name:        "United Kingdom of Great Britain and Northern Ireland",
+		CountryCode: "826",
+	},
+	"BES": {
+		Alpha3:      "BES",
+		Name:        "Bonaire, Sint Eustatius and Saba",
+		CountryCode: "535",
+	},
+	"GUY": {
+		Alpha3:      "GUY",
+		Name:        "Guyana",
+		CountryCode: "328",
+	},
+	"CRI": {
+		Alpha3:      "CRI",
+		Name:        "Costa Rica",
+		CountryCode: "188",
+	},
+	"ETH": {
+		Alpha3:      "ETH",
+		Name:        "Ethiopia",
+		CountryCode: "231",
+	},
+	"MNP": {
+		Alpha3:      "MNP",
+		Name:        "Northern Mariana Islands",
+		CountryCode: "580",
+	},
+	"UMI": {
+		Alpha3:      "UMI",
+		Name:        "United States Minor Outlying Islands",
+		CountryCode: "581",
+	},
+	"HUN": {
+		Alpha3:      "HUN",
+		Name:        "Hungary",
+		CountryCode: "348",
+	},
+	"TKM": {
+		Alpha3:      "TKM",
+		Name:        "Turkmenistan",
+		CountryCode: "795",
+	},
+	"TTO": {
+		Alpha3:      "TTO",
+		Name:        "Trinidad and Tobago",
+		CountryCode: "780",
+	},
+	"NLD": {
+		Alpha3:      "NLD",
+		Name:        "Netherlands",
+		CountryCode: "528",
+	},
+	"COM": {
+		Alpha3:      "COM",
+		Name:        "Comoros",
+		CountryCode: "174",
+	},
+	"BMU": {
+		Alpha3:      "BMU",
+		Name:        "Bermuda",
+		CountryCode: "060",
+	},
+	"HMD": {
+		Alpha3:      "HMD",
+		Name:        "Heard Island and McDonald Islands",
+		CountryCode: "334",
+	},
+	"TCD": {
+		Alpha3:      "TCD",
+		Name:        "Chad",
+		CountryCode: "148",
+	},
+	"GEO": {
+		Alpha3:      "GEO",
+		Name:        "Georgia",
+		CountryCode: "268",
+	},
+	"ROU": {
+		Alpha3:      "ROU",
+		Name:        "Romania",
+		CountryCode: "642",
+	},
+	"TCA": {
+		Alpha3:      "TCA",
+		Name:        "Turks and Caicos Islands",
+		CountryCode: "796",
+	},
+	"MHL": {
+		Alpha3:      "MHL",
+		Name:        "Marshall Islands",
+		CountryCode: "584",
+	},
+	"MLI": {
+		Alpha3:      "MLI",
+		Name:        "Mali",
+		CountryCode: "466",
+	},
+	"BLZ": {
+		Alpha3:      "BLZ",
+		Name:        "Belize",
+		CountryCode: "084",
+	},
+	"BDI": {
+		Alpha3:      "BDI",
+		Name:        "Burundi",
+		CountryCode: "108",
+	},
+	"SWE": {
+		Alpha3:      "SWE",
+		Name:        "Sweden",
+		CountryCode: "752",
+	},
+	"AFG": {
+		Alpha3:      "AFG",
+		Name:        "Afghanistan",
+		CountryCode: "004",
+	},
+	"NFK": {
+		Alpha3:      "NFK",
+		Name:        "Norfolk Island",
+		CountryCode: "574",
+	},
+	"VGB": {
+		Alpha3:      "VGB",
+		Name:        "Virgin Islands (British)",
+		CountryCode: "092",
+	},
+	"BLR": {
+		Alpha3:      "BLR",
+		Name:        "Belarus",
+		CountryCode: "112",
+	},
+	"BLM": {
+		Alpha3:      "BLM",
+		Name:        "Saint Barthélemy",
+		CountryCode: "652",
+	},
+	"GRD": {
+		Alpha3:      "GRD",
+		Name:        "Grenada",
+		CountryCode: "308",
+	},
+	"ALA": {
+		Alpha3:      "ALA",
+		Name:        "Åland Islands",
+		CountryCode: "248",
+	},
+	"GRC": {
+		Alpha3:      "GRC",
+		Name:        "Greece",
+		CountryCode: "300",
+	},
+	"RUS": {
+		Alpha3:      "RUS",
+		Name:        "Russian Federation",
+		CountryCode: "643",
+	},
+	"GRL": {
+		Alpha3:      "GRL",
+		Name:        "Greenland",
+		CountryCode: "304",
+	},
+	"SHN": {
+		Alpha3:      "SHN",
+		Name:        "Saint Helena, Ascension and Tristan da Cunha",
+		CountryCode: "654",
+	},
+	"AND": {
+		Alpha3:      "AND",
+		Name:        "Andorra",
+		CountryCode: "020",
+	},
+	"MOZ": {
+		Alpha3:      "MOZ",
+		Name:        "Mozambique",
+		CountryCode: "508",
+	},
+	"ARG": {
+		Alpha3:      "ARG",
+		Name:        "Argentina",
+		CountryCode: "032",
+	},
+	"TJK": {
+		Alpha3:      "TJK",
+		Name:        "Tajikistan",
+		CountryCode: "762",
+	},
+	"THA": {
+		Alpha3:      "THA",
+		Name:        "Thailand",
+		CountryCode: "764",
+	},
+	"HTI": {
+		Alpha3:      "HTI",
+		Name:        "Haiti",
+		CountryCode: "332",
+	},
+	"PSE": {
+		Alpha3:      "PSE",
+		Name:        "Palestine, State of",
+		CountryCode: "275",
+	},
+	"LCA": {
+		Alpha3:      "LCA",
+		Name:        "Saint Lucia",
+		CountryCode: "662",
+	},
+	"IND": {
+		Alpha3:      "IND",
+		Name:        "India",
+		CountryCode: "356",
+	},
+	"SSD": {
+		Alpha3:      "SSD",
+		Name:        "South Sudan",
+		CountryCode: "728",
+	},
+	"BTN": {
+		Alpha3:      "BTN",
+		Name:        "Bhutan",
+		CountryCode: "064",
+	},
+	"VCT": {
+		Alpha3:      "VCT",
+		Name:        "Saint Vincent and the Grenadines",
+		CountryCode: "670",
+	},
+	"VNM": {
+		Alpha3:      "VNM",
+		Name:        "Viet Nam",
+		CountryCode: "704",
+	},
+	"NOR": {
+		Alpha3:      "NOR",
+		Name:        "Norway",
+		CountryCode: "578",
+	},
+	"CZE": {
+		Alpha3:      "CZE",
+		Name:        "Czechia",
+		CountryCode: "203",
+	},
+	"ATF": {
+		Alpha3:      "ATF",
+		Name:        "French Southern Territories",
+		CountryCode: "260",
+	},
+	"ATG": {
+		Alpha3:      "ATG",
+		Name:        "Antigua and Barbuda",
+		CountryCode: "028",
+	},
+	"FJI": {
+		Alpha3:      "FJI",
+		Name:        "Fiji",
+		CountryCode: "242",
+	},
+	"HND": {
+		Alpha3:      "HND",
+		Name:        "Honduras",
+		CountryCode: "340",
+	},
+	"MUS": {
+		Alpha3:      "MUS",
+		Name:        "Mauritius",
+		CountryCode: "480",
+	},
+	"DOM": {
+		Alpha3:      "DOM",
+		Name:        "Dominican Republic",
+		CountryCode: "214",
+	},
+	"LUX": {
+		Alpha3:      "LUX",
+		Name:        "Luxembourg",
+		CountryCode: "442",
+	},
+	"ISR": {
+		Alpha3:      "ISR",
+		Name:        "Israel",
+		CountryCode: "376",
+	},
+	"SMR": {
+		Alpha3:      "SMR",
+		Name:        "San Marino",
+		CountryCode: "674",
+	},
+	"PER": {
+		Alpha3:      "PER",
+		Name:        "Peru",
+		CountryCode: "604",
+	},
+	"SXM": {
+		Alpha3:      "SXM",
+		Name:        "Sint Maarten (Dutch part)",
+		CountryCode: "534",
+	},
+	"IDN": {
+		Alpha3:      "IDN",
+		Name:        "Indonesia",
+		CountryCode: "360",
+	},
+	"VUT": {
+		Alpha3:      "VUT",
+		Name:        "Vanuatu",
+		CountryCode: "548",
+	},
+	"GNQ": {
+		Alpha3:      "GNQ",
+		Name:        "Equatorial Guinea",
+		CountryCode: "226",
+	},
+	"SUR": {
+		Alpha3:      "SUR",
+		Name:        "Suriname",
+		CountryCode: "740",
+	},
+	"COG": {
+		Alpha3:      "COG",
+		Name:        "Congo",
+		CountryCode: "178",
+	},
+	"ISL": {
+		Alpha3:      "ISL",
+		Name:        "Iceland",
+		CountryCode: "352",
+	},
+	"GLP": {
+		Alpha3:      "GLP",
+		Name:        "Guadeloupe",
+		CountryCode: "312",
+	},
+	"GAB": {
+		Alpha3:      "GAB",
+		Name:        "Gabon",
+		CountryCode: "266",
+	},
+	"COK": {
+		Alpha3:      "COK",
+		Name:        "Cook Islands",
+		CountryCode: "184",
+	},
+	"NER": {
+		Alpha3:      "NER",
+		Name:        "Niger",
+		CountryCode: "562",
+	},
+	"COL": {
+		Alpha3:      "COL",
+		Name:        "Colombia",
+		CountryCode: "170",
+	},
+	"NGA": {
+		Alpha3:      "NGA",
+		Name:        "Nigeria",
+		CountryCode: "566",
+	},
+	"PRT": {
+		Alpha3:      "PRT",
+		Name:        "Portugal",
+		CountryCode: "620",
+	},
+	"NRU": {
+		Alpha3:      "NRU",
+		Name:        "Nauru",
+		CountryCode: "520",
+	},
+	"MDA": {
+		Alpha3:      "MDA",
+		Name:        "Moldova, Republic of",
+		CountryCode: "498",
+	},
+	"GGY": {
+		Alpha3:      "GGY",
+		Name:        "Guernsey",
+		CountryCode: "831",
+	},
+	"MDG": {
+		Alpha3:      "MDG",
+		Name:        "Madagascar",
+		CountryCode: "450",
+	},
+	"ATA": {
+		Alpha3:      "ATA",
+		Name:        "Antarctica",
+		CountryCode: "010",
+	},
+	"ECU": {
+		Alpha3:      "ECU",
+		Name:        "Ecuador",
+		CountryCode: "218",
+	},
+	"SEN": {
+		Alpha3:      "SEN",
+		Name:        "Senegal",
+		CountryCode: "686",
+	},
+	"NZL": {
+		Alpha3:      "NZL",
+		Name:        "New Zealand",
+		CountryCode: "554",
+	},
+	"MDV": {
+		Alpha3:      "MDV",
+		Name:        "Maldives",
+		CountryCode: "462",
+	},
+	"ASM": {
+		Alpha3:      "ASM",
+		Name:        "American Samoa",
+		CountryCode: "016",
+	},
+	"SPM": {
+		Alpha3:      "SPM",
+		Name:        "Saint Pierre and Miquelon",
+		CountryCode: "666",
+	},
+	"TLS": {
+		Alpha3:      "TLS",
+		Name:        "Timor-Leste",
+		CountryCode: "626",
+	},
+	"FRA": {
+		Alpha3:      "FRA",
+		Name:        "France",
+		CountryCode: "250",
+	},
+	"LTU": {
+		Alpha3:      "LTU",
+		Name:        "Lithuania",
+		CountryCode: "440",
+	},
+	"RWA": {
+		Alpha3:      "RWA",
+		Name:        "Rwanda",
+		CountryCode: "646",
+	},
+	"ZMB": {
+		Alpha3:      "ZMB",
+		Name:        "Zambia",
+		CountryCode: "894",
+	},
+	"TWN": {
+		Alpha3:      "TWN",
+		Name:        "Taiwan, Province of China",
+		CountryCode: "158",
+	},
+	"WLF": {
+		Alpha3:      "WLF",
+		Name:        "Wallis and Futuna",
+		CountryCode: "876",
+	},
+	"JEY": {
+		Alpha3:      "JEY",
+		Name:        "Jersey",
+		CountryCode: "832",
+	},
+	"FRO": {
+		Alpha3:      "FRO",
+		Name:        "Faroe Islands",
+		CountryCode: "234",
+	},
+	"GTM": {
+		Alpha3:      "GTM",
+		Name:        "Guatemala",
+		CountryCode: "320",
+	},
+	"DNK": {
+		Alpha3:      "DNK",
+		Name:        "Denmark",
+		CountryCode: "208",
+	},
+	"ZWE": {
+		Alpha3:      "ZWE",
+		Name:        "Zimbabwe",
+		CountryCode: "716",
+	},
+	"MAF": {
+		Alpha3:      "MAF",
+		Name:        "Saint Martin (French part)",
+		CountryCode: "663",
+	},
+	"AUS": {
+		Alpha3:      "AUS",
+		Name:        "Australia",
+		CountryCode: "036",
+	},
+	"AUT": {
+		Alpha3:      "AUT",
+		Name:        "Austria",
+		CountryCode: "040",
+	},
+	"SJM": {
+		Alpha3:      "SJM",
+		Name:        "Svalbard and Jan Mayen",
+		CountryCode: "744",
+	},
+	"VEN": {
+		Alpha3:      "VEN",
+		Name:        "Venezuela (Bolivarian Republic of)",
+		CountryCode: "862",
+	},
+	"IRN": {
+		Alpha3:      "IRN",
+		Name:        "Iran (Islamic Republic of)",
+		CountryCode: "364",
+	},
+	"PLW": {
+		Alpha3:      "PLW",
+		Name:        "Palau",
+		CountryCode: "585",
+	},
+	"KEN": {
+		Alpha3:      "KEN",
+		Name:        "Kenya",
+		CountryCode: "404",
+	},
+	"LAO": {
+		Alpha3:      "LAO",
+		Name:        "Lao People's Democratic Republic",
+		CountryCode: "418",
+	},
+	"WSM": {
+		Alpha3:      "WSM",
+		Name:        "Samoa",
+		CountryCode: "882",
+	},
+	"TUR": {
+		Alpha3:      "TUR",
+		Name:        "Turkey",
+		CountryCode: "792",
+	},
+	"JPN": {
+		Alpha3:      "JPN",
+		Name:        "Japan",
+		CountryCode: "392",
+	},
+	"ALB": {
+		Alpha3:      "ALB",
+		Name:        "Albania",
+		CountryCode: "008",
+	},
+	"OMN": {
+		Alpha3:      "OMN",
+		Name:        "Oman",
+		CountryCode: "512",
+	},
+	"TUV": {
+		Alpha3:      "TUV",
+		Name:        "Tuvalu",
+		CountryCode: "798",
+	},
+	"MMR": {
+		Alpha3:      "MMR",
+		Name:        "Myanmar",
+		CountryCode: "104",
+	},
+	"BRN": {
+		Alpha3:      "BRN",
+		Name:        "Brunei Darussalam",
+		CountryCode: "096",
+	},
+	"TUN": {
+		Alpha3:      "TUN",
+		Name:        "Tunisia",
+		CountryCode: "788",
+	},
+	"PCN": {
+		Alpha3:      "PCN",
+		Name:        "Pitcairn",
+		CountryCode: "612",
+	},
+	"MEX": {
+		Alpha3:      "MEX",
+		Name:        "Mexico",
+		CountryCode: "484",
+	},
+	"BRA": {
+		Alpha3:      "BRA",
+		Name:        "Brazil",
+		CountryCode: "076",
+	},
+	"CAN": {
+		Alpha3:      "CAN",
+		Name:        "Canada",
+		CountryCode: "124",
+	},
+	"CUW": {
+		Alpha3:      "CUW",
+		Name:        "Curaçao",
+		CountryCode: "531",
+	},
+	"MKD": {
+		Alpha3:      "MKD",
+		Name:        "North Macedonia",
+		CountryCode: "807",
+	},
+	"USA": {
+		Alpha3:      "USA",
+		Name:        "United States of America",
+		CountryCode: "840",
+	},
+	"QAT": {
+		Alpha3:      "QAT",
+		Name:        "Qatar",
+		CountryCode: "634",
+	},
+	"LVA": {
+		Alpha3:      "LVA",
+		Name:        "Latvia",
+		CountryCode: "428",
+	},
+	"MSR": {
+		Alpha3:      "MSR",
+		Name:        "Montserrat",
+		CountryCode: "500",
+	},
+	"GNB": {
+		Alpha3:      "GNB",
+		Name:        "Guinea-Bissau",
+		CountryCode: "624",
+	},
+	"SWZ": {
+		Alpha3:      "SWZ",
+		Name:        "Eswatini",
+		CountryCode: "748",
+	},
+	"TON": {
+		Alpha3:      "TON",
+		Name:        "Tonga",
+		CountryCode: "776",
+	},
+	"CIV": {
+		Alpha3:      "CIV",
+		Name:        "Côte d'Ivoire",
+		CountryCode: "384",
+	},
+	"UKR": {
+		Alpha3:      "UKR",
+		Name:        "Ukraine",
+		CountryCode: "804",
+	},
+	"KOR": {
+		Alpha3:      "KOR",
+		Name:        "Korea, Republic of",
+		CountryCode: "410",
+	},
+	"AIA": {
+		Alpha3:      "AIA",
+		Name:        "Anguilla",
+		CountryCode: "660",
+	},
+	"CAF": {
+		Alpha3:      "CAF",
+		Name:        "Central African Republic",
+		CountryCode: "140",
+	},
+	"CHE": {
+		Alpha3:      "CHE",
+		Name:        "Switzerland",
+		CountryCode: "756",
+	},
+	"CYP": {
+		Alpha3:      "CYP",
+		Name:        "Cyprus",
+		CountryCode: "196",
+	},
+	"BIH": {
+		Alpha3:      "BIH",
+		Name:        "Bosnia and Herzegovina",
+		CountryCode: "070",
+	},
+	"SGP": {
+		Alpha3:      "SGP",
+		Name:        "Singapore",
+		CountryCode: "702",
+	},
+	"SGS": {
+		Alpha3:      "SGS",
+		Name:        "South Georgia and the South Sandwich Islands",
+		CountryCode: "239",
+	},
+	"AZE": {
+		Alpha3:      "AZE",
+		Name:        "Azerbaijan",
+		CountryCode: "031",
+	},
+	"UZB": {
+		Alpha3:      "UZB",
+		Name:        "Uzbekistan",
+		CountryCode: "860",
+	},
+	"CMR": {
+		Alpha3:      "CMR",
+		Name:        "Cameroon",
+		CountryCode: "120",
+	},
+	"SRB": {
+		Alpha3:      "SRB",
+		Name:        "Serbia",
+		CountryCode: "688",
+	},
+	"POL": {
+		Alpha3:      "POL",
+		Name:        "Poland",
+		CountryCode: "616",
+	},
+	"KWT": {
+		Alpha3:      "KWT",
+		Name:        "Kuwait",
+		CountryCode: "414",
+	},
+	"GMB": {
+		Alpha3:      "GMB",
+		Name:        "Gambia",
+		CountryCode: "270",
+	},
+	"ERI": {
+		Alpha3:      "ERI",
+		Name:        "Eritrea",
+		CountryCode: "232",
+	},
+	"NCL": {
+		Alpha3:      "NCL",
+		Name:        "New Caledonia",
+		CountryCode: "540",
+	},
+	"TGO": {
+		Alpha3:      "TGO",
+		Name:        "Togo",
+		CountryCode: "768",
+	},
+	"CYM": {
+		Alpha3:      "CYM",
+		Name:        "Cayman Islands",
+		CountryCode: "136",
+	},
+	"EST": {
+		Alpha3:      "EST",
+		Name:        "Estonia",
+		CountryCode: "233",
+	},
+	"MWI": {
+		Alpha3:      "MWI",
+		Name:        "Malawi",
+		CountryCode: "454",
+	},
+	"ESP": {
+		Alpha3:      "ESP",
+		Name:        "Spain",
+		CountryCode: "724",
+	},
+	"IRQ": {
+		Alpha3:      "IRQ",
+		Name:        "Iraq",
+		CountryCode: "368",
+	},
+	"SLV": {
+		Alpha3:      "SLV",
+		Name:        "El Salvador",
+		CountryCode: "222",
+	},
+	"MTQ": {
+		Alpha3:      "MTQ",
+		Name:        "Martinique",
+		CountryCode: "474",
+	},
+	"STP": {
+		Alpha3:      "STP",
+		Name:        "Sao Tome and Principe",
+		CountryCode: "678",
+	},
+	"MLT": {
+		Alpha3:      "MLT",
+		Name:        "Malta",
+		CountryCode: "470",
+	},
+	"ABW": {
+		Alpha3:      "ABW",
+		Name:        "Aruba",
+		CountryCode: "533",
+	},
+	"SLE": {
+		Alpha3:      "SLE",
+		Name:        "Sierra Leone",
+		CountryCode: "694",
+	},
+	"IMN": {
+		Alpha3:      "IMN",
+		Name:        "Isle of Man",
+		CountryCode: "833",
+	},
+	"PAN": {
+		Alpha3:      "PAN",
+		Name:        "Panama",
+		CountryCode: "591",
+	},
+	"BHS": {
+		Alpha3:      "BHS",
+		Name:        "Bahamas",
+		CountryCode: "044",
+	},
+	"SLB": {
+		Alpha3:      "SLB",
+		Name:        "Solomon Islands",
+		CountryCode: "090",
+	},
+	"ESH": {
+		Alpha3:      "ESH",
+		Name:        "Western Sahara",
+		CountryCode: "732",
+	},
+	"MCO": {
+		Alpha3:      "MCO",
+		Name:        "Monaco",
+		CountryCode: "492",
+	},
+	"ITA": {
+		Alpha3:      "ITA",
+		Name:        "Italy",
+		CountryCode: "380",
+	},
+	"COD": {
+		Alpha3:      "COD",
+		Name:        "Congo, Democratic Republic of the",
+		CountryCode: "180",
+	},
+	"BRB": {
+		Alpha3:      "BRB",
+		Name:        "Barbados",
+		CountryCode: "052",
+	},
+	"KGZ": {
+		Alpha3:      "KGZ",
+		Name:        "Kyrgyzstan",
+		CountryCode: "417",
+	},
+	"ARM": {
+		Alpha3:      "ARM",
+		Name:        "Armenia",
+		CountryCode: "051",
+	},
+	"UGA": {
+		Alpha3:      "UGA",
+		Name:        "Uganda",
+		CountryCode: "800",
+	},
+	"FSM": {
+		Alpha3:      "FSM",
+		Name:        "Micronesia (Federated States of)",
+		CountryCode: "583",
+	},
+	"ARE": {
+		Alpha3:      "ARE",
+		Name:        "United Arab Emirates",
+		CountryCode: "784",
+	},
+	"LSO": {
+		Alpha3:      "LSO",
+		Name:        "Lesotho",
+		CountryCode: "426",
+	},
+	"SDN": {
+		Alpha3:      "SDN",
+		Name:        "Sudan",
+		CountryCode: "729",
+	},
+	"BHR": {
+		Alpha3:      "BHR",
+		Name:        "Bahrain",
+		CountryCode: "048",
+	},
+	"TKL": {
+		Alpha3:      "TKL",
+		Name:        "Tokelau",
+		CountryCode: "772",
+	},
+	"PNG": {
+		Alpha3:      "PNG",
+		Name:        "Papua New Guinea",
+		CountryCode: "598",
+	},
+	"CUB": {
+		Alpha3:      "CUB",
+		Name:        "Cuba",
+		CountryCode: "192",
+	},
+}


### PR DESCRIPTION
**Why?**

This change will allow us to adjust the amount users from each country receive when verifying with Jumio. Currently, the approach has been to turn off jumio for countries that have users who are trying to game the verification system. After this change, we'll be able to open up to more countries and modify the amount we give as a sign-up bonus.

**What's been done:**

- create utils directory and a constant that allows us to look up country names from country alpha-3 codes
- Add admin endpoints to get all sign-up bonus configurations and edit a single country's sign up bonus amount
- Default sign-up bonus amount is now specified in USD cents instead of DeSo nanos
- Update Jumio callback to use the new logic to get amount to pay referrer and referee
- Fix global state tests.