### PR TITLE
use min of richListLength constant and length of rich list when taking the top 1k

### DIFF
--- a/routes/supply.go
+++ b/routes/supply.go
@@ -87,7 +87,12 @@ func (fes *APIServer) StartSupplyMonitoring() {
 					return richList[ii].BalanceNanos > richList[jj].BalanceNanos
 				})
 
-				richList = richList[:richListLength]
+				endIdx := richListLength
+				if len(richList) < richListLength {
+					endIdx = len(richList)
+				}
+
+				richList = richList[:endIdx]
 
 				// Convert RichListEntries to RichListEntryResponses
 				var richListResponses []RichListEntryResponse


### PR DESCRIPTION
When running n0_test, taking the slice up to 1000 would result in a panic since the length of the rich list would be less than 1000