### PR TITLE
Z/threaded comments

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/deso-protocol/backend
 
 go 1.16
 
-replace github.com/deso-protocol/core => ../core/
+replace github.com/deso-protocol/core => ../../core/
 
 require (
 	cloud.google.com/go/storage v1.15.0

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/deso-protocol/backend
 
 go 1.16
 
-replace github.com/deso-protocol/core => ../../core/
+replace github.com/deso-protocol/core => ../core/
 
 require (
 	cloud.google.com/go/storage v1.15.0

--- a/routes/post.go
+++ b/routes/post.go
@@ -1462,7 +1462,7 @@ func (fes *APIServer) GetSinglePostComments(
 	// Limit comments to leaf limit, if it's not the first reply level and the leaf limit isn't -1
 	var limitedComments []*PostEntryResponse
 
-	if requestData.ThreadLeafLimit == -1 || commentLevel == 0 {
+	if requestData.ThreadLeafLimit == -1 || commentLevel == 0 || int32(len(comments)) <= requestData.ThreadLeafLimit {
 		limitedComments = comments
 	} else {
 		limitedComments = comments[:requestData.ThreadLeafLimit]

--- a/routes/post.go
+++ b/routes/post.go
@@ -1459,7 +1459,16 @@ func (fes *APIServer) GetSinglePostComments(
 		}
 	}
 
-	postEntryResponse.Comments = comments
+	// Limit comments to leaf limit, if it's not the first reply level and the leaf limit isn't -1
+	var limitedComments []*PostEntryResponse
+
+	if requestData.ThreadLeafLimit == -1 || commentLevel == 0 {
+		limitedComments = comments
+	} else {
+		limitedComments = comments[:requestData.ThreadLeafLimit]
+	}
+
+	postEntryResponse.Comments = limitedComments
 	return comments, nil
 }
 

--- a/routes/post.go
+++ b/routes/post.go
@@ -1220,6 +1220,7 @@ func (fes *APIServer) GetSinglePost(ww http.ResponseWriter, req *http.Request) {
 	}
 }
 
+// Include poster public key in comments response
 type CommentsPostEntryResponse struct {
 	PostEntryResponse *PostEntryResponse
 	PosterPublicKeyBytes [] byte
@@ -1319,6 +1320,7 @@ func (fes *APIServer) GetSinglePostComments(
 		}
 		commentEntryResponse.ProfileEntryResponse = commentProfileEntryResponse
 		commentEntryResponse.PostEntryReaderState = utxoView.GetPostEntryReaderState(readerPublicKeyBytes, commentEntry)
+		// Include poster public key in comments response
 		commentEntryResponseWithPosterBytes := &CommentsPostEntryResponse{}
 		commentEntryResponseWithPosterBytes.PostEntryResponse = commentEntryResponse
 		commentEntryResponseWithPosterBytes.PosterPublicKeyBytes = commentEntry.PosterPublicKey

--- a/routes/post.go
+++ b/routes/post.go
@@ -1027,12 +1027,12 @@ func (fes *APIServer) GetSinglePost(ww http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	// Fetch the commentEntries for the post.
-	commentEntries, err := utxoView.GetCommentEntriesForParentStakeID(postHash[:])
-	if err != nil {
-		_AddBadRequestError(ww, fmt.Sprintf("GetSinglePost: Error getting commentEntries: %v: %s", err, requestData.PostHashHex))
-		return
-	}
+	//// Fetch the commentEntries for the post.
+	//commentEntries, err := utxoView.GetCommentEntriesForParentStakeID(postHash[:])
+	//if err != nil {
+	//	_AddBadRequestError(ww, fmt.Sprintf("GetSinglePost: Error getting commentEntries: %v: %s", err, requestData.PostHashHex))
+	//	return
+	//}
 
 	// Fetch the parents for the post.
 	var parentPostEntries []*lib.PostEntry
@@ -1196,7 +1196,6 @@ func (fes *APIServer) GetSinglePost(ww http.ResponseWriter, req *http.Request) {
 	}
 
 	comments, err := fes.GetSinglePostComments(
-		commentEntries,
 		utxoView,
 		pubKeyToProfileEntryResponseMap,
 		postEntryResponse,
@@ -1228,7 +1227,6 @@ func (fes *APIServer) GetSinglePost(ww http.ResponseWriter, req *http.Request) {
 }
 
 func (fes *APIServer) GetSinglePostComments(
-	commentEntries []*lib.PostEntry,
 	utxoView *lib.UtxoView,
 	pubKeyToProfileEntryResponseMap map[lib.PkMapKey]*ProfileEntryResponse,
 	postEntryResponse *PostEntryResponse,
@@ -1241,6 +1239,16 @@ func (fes *APIServer) GetSinglePostComments(
 	blockedPublicKeys map[string]struct{},
 	commentLevel uint32,
 ) ([]*PostEntryResponse, error) {
+	postHash, err := GetPostHashFromPostHashHex(postEntryResponse.PostHashHex)
+	if err != nil {
+		return nil, err
+	}
+
+	// Fetch the commentEntries for the post.
+	commentEntries, err := utxoView.GetCommentEntriesForParentStakeID(postHash[:])
+	if err != nil {
+		return nil, err
+	}
 
 	// Process the comments into something we can return.
 	commentEntryResponseList := []*PostEntryResponse{}
@@ -1358,7 +1366,6 @@ func (fes *APIServer) GetSinglePostComments(
 	if commentLevel < requestData.ThreadLevelLimit {
 		for _, comment := range comments {
 			commentReplies, err := fes.GetSinglePostComments(
-				commentEntries,
 				utxoView,
 				pubKeyToProfileEntryResponseMap,
 				comment,

--- a/routes/post.go
+++ b/routes/post.go
@@ -1430,6 +1430,8 @@ func (fes *APIServer) GetSinglePostComments(
 	var comments []*PostEntryResponse
 	if commentEntryResponseLength > requestData.CommentOffset && commentLevel == 0 {
 		comments = commentEntryResponseList[requestData.CommentOffset:maxIdx]
+	} else {
+		comments = commentEntryResponseList
 	}
 
 	for ii, comment := range comments {

--- a/routes/post.go
+++ b/routes/post.go
@@ -1372,7 +1372,7 @@ func (fes *APIServer) GetSinglePostComments(
 	}
 
 	for ii, comment := range comments {
-		glog.Infof("Iterating through comment: %v", comment.Body)
+		glog.Infof("Iterating through this comment: %v", comment.Body)
 		// If the previous stack was loading the comment author thread and the comment in question is from the same author, load it.
 		loadCommentAuthorThread := loadAuthorThread && comment.PosterPublicKeyBase58Check == topLevelPosterPublicKeyBase58Check
 		// Only iterate over comments within the specified leaf-limit. To follow a single reply thread, that limit would be 1. All top-level replies are included. A limit of -1 includes all leafs.

--- a/routes/post.go
+++ b/routes/post.go
@@ -1259,6 +1259,8 @@ func (fes *APIServer) GetSinglePostComments(
 		return nil, err
 	}
 
+	glog.Infof("Fetched this many entries: %v", len(commentEntries))
+
 	// Process the comments into something we can return.
 	commentEntryResponseList := []*PostEntryResponse{}
 	// Create a map from commentEntryPostHashHex to commentEntry to ease look up of public key bytes when sorting

--- a/routes/post.go
+++ b/routes/post.go
@@ -1469,7 +1469,7 @@ func (fes *APIServer) GetSinglePostComments(
 	}
 
 	postEntryResponse.Comments = limitedComments
-	return comments, nil
+	return limitedComments, nil
 }
 
 // GetPostsForPublicKeyRequest ...

--- a/routes/post.go
+++ b/routes/post.go
@@ -1200,10 +1200,8 @@ func (fes *APIServer) GetSinglePost(ww http.ResponseWriter, req *http.Request) {
 	glog.Infof("\nGetting comments for: %v \n", postEntryResponse.Body)
 	comments, err := fes.GetSinglePostComments(
 		utxoView,
-		pubKeyToProfileEntryResponseMap,
 		postEntryResponse,
 		isCurrentPosterBlocked,
-		isCurrentPosterGreylisted,
 		ww,
 		requestData,
 		readerPublicKeyBytes,
@@ -1235,10 +1233,8 @@ func (fes *APIServer) GetSinglePost(ww http.ResponseWriter, req *http.Request) {
 // Get the comments associated with a single post.
 func (fes *APIServer) GetSinglePostComments(
 	utxoView *lib.UtxoView,
-	pubKeyToProfileEntryResponseMap map[lib.PkMapKey]*ProfileEntryResponse,
 	postEntryResponse *PostEntryResponse,
 	isCurrentPosterBlocked bool,
-	isCurrentPosterGreylisted bool,
 	ww http.ResponseWriter,
 	requestData GetSinglePostRequest,
 	readerPublicKeyBytes []byte,
@@ -1248,6 +1244,56 @@ func (fes *APIServer) GetSinglePostComments(
 	loadAuthorThread bool,
 	topLevelPosterPublicKeyBase58Check string,
 ) ([]*PostEntryResponse, error) {
+	// Filter out restricted PosterPublicKeys.
+	filteredProfilePubKeyMap, err := fes.FilterOutRestrictedPubKeysFromMap(
+		profilePubKeyMap, readerPublicKeyBytes, "leaderboard" /*moderationType*/, utxoView)
+	if err != nil {
+		return nil, err
+	}
+
+	// Figure out if the current poster is greylisted.  If the current poster is greylisted, we will add their
+	// public key back to the filteredProfileMap so their profile will appear for the current post
+	// and any parents, but we will remove any comments by this greylisted user.
+	isCurrentPosterGreylisted := false
+	posterPublicKey, err := hex.DecodeString(postEntryResponse.PosterPublicKeyBase58Check)
+	if _, ok := filteredProfilePubKeyMap[lib.MakePkMapKey(posterPublicKey)]; !ok {
+		// Get the userMetadata for the currentPosters
+		currentPosterUserMetadataKey := append([]byte{}, _GlobalStatePrefixPublicKeyToUserMetadata...)
+		currentPosterUserMetadataKey = append(currentPosterUserMetadataKey, posterPublicKey...)
+		var currentPosterUserMetadataBytes []byte
+		currentPosterUserMetadataBytes, err = fes.GlobalState.Get(currentPosterUserMetadataKey)
+		if err != nil {
+			return nil, err
+		}
+		// If the currentPoster's userMetadata doesn't exist, then they are no greylisted, so we can exit.
+		if currentPosterUserMetadataBytes != nil {
+			// Decode the currentPoster's userMetadata.
+			currentPosterUserMetadata := UserMetadata{}
+			err = gob.NewDecoder(bytes.NewReader(currentPosterUserMetadataBytes)).Decode(&currentPosterUserMetadata)
+			if err != nil {
+				return nil, err
+			}
+			// If the currentPoster is not blacklisted (removed everywhere) and is greylisted (removed from leaderboard)
+			// add them back to the filteredProfilePubKeyMap and note that the currentPoster is greylisted.
+			if currentPosterUserMetadata.RemoveFromLeaderboard && !currentPosterUserMetadata.RemoveEverywhere {
+				isCurrentPosterGreylisted = true
+				filteredProfilePubKeyMap[lib.MakePkMapKey(posterPublicKey)] = posterPublicKey
+			}
+		}
+	}
+
+	// Get the profile entry for all PosterPublicKeys that passed our filter.
+	pubKeyToProfileEntryResponseMap := make(map[lib.PkMapKey]*ProfileEntryResponse)
+	for _, pubKeyBytes := range filteredProfilePubKeyMap {
+		profileEntry := utxoView.GetProfileEntryForPublicKey(pubKeyBytes)
+		if profileEntry == nil {
+			continue
+		} else {
+			pubKeyToProfileEntryResponseMap[lib.MakePkMapKey(pubKeyBytes)] =
+				fes._profileEntryToResponse(profileEntry, utxoView)
+		}
+	}
+
 	postHash, err := GetPostHashFromPostHashHex(postEntryResponse.PostHashHex)
 	if err != nil {
 		return nil, err
@@ -1387,10 +1433,8 @@ func (fes *APIServer) GetSinglePostComments(
 		if commentWithinLeafLimit && commentWithinThreadLevelLimit {
 			commentReplies, err := fes.GetSinglePostComments(
 				utxoView,
-				pubKeyToProfileEntryResponseMap,
 				comment,
 				isCurrentPosterBlocked,
-				isCurrentPosterGreylisted,
 				ww,
 				requestData,
 				readerPublicKeyBytes,

--- a/routes/post.go
+++ b/routes/post.go
@@ -1197,7 +1197,7 @@ func (fes *APIServer) GetSinglePost(ww http.ResponseWriter, req *http.Request) {
 		parentPostEntryResponseList = append(parentPostEntryResponseList, parentEntryResponse)
 	}
 
-	glog.Infof("Getting comments for: %v", postEntryResponse.Body)
+	glog.Infof("\nGetting comments for: %v \n", postEntryResponse.Body)
 	comments, err := fes.GetSinglePostComments(
 		utxoView,
 		pubKeyToProfileEntryResponseMap,
@@ -1259,6 +1259,7 @@ func (fes *APIServer) GetSinglePostComments(
 		return nil, err
 	}
 
+	glog.Infof("\nHere are the comment entries: %v \n", commentEntries)
 	// Process the comments into something we can return.
 	commentEntryResponseList := []*PostEntryResponse{}
 	// Create a map from commentEntryPostHashHex to commentEntry to ease look up of public key bytes when sorting
@@ -1270,6 +1271,7 @@ func (fes *APIServer) GetSinglePostComments(
 	}
 
 	for _, commentEntry := range commentEntries {
+		glog.Infof("\nHere are the comment entries: %v \n", commentEntry)
 		pkMapKey := lib.MakePkMapKey(commentEntry.PosterPublicKey)
 		// Remove comments that are blocked by either the reader or the poster of the root post
 		if _, ok := blockedPublicKeys[lib.PkToString(commentEntry.PosterPublicKey, fes.Params)]; !ok && profilePubKeyMap[pkMapKey] == nil {
@@ -1372,7 +1374,7 @@ func (fes *APIServer) GetSinglePostComments(
 	}
 
 	for ii, comment := range comments {
-		glog.Infof("Iterating through the comment: %v", comment.Body)
+		glog.Infof("\nIterating through the comment: %v \n", comment.Body)
 		// If the previous stack was loading the comment author thread and the comment in question is from the same author, load it.
 		loadCommentAuthorThread := loadAuthorThread && comment.PosterPublicKeyBase58Check == topLevelPosterPublicKeyBase58Check
 		// Only iterate over comments within the specified leaf-limit. To follow a single reply thread, that limit would be 1. All top-level replies are included. A limit of -1 includes all leafs.

--- a/routes/post.go
+++ b/routes/post.go
@@ -1271,7 +1271,7 @@ func (fes *APIServer) GetSinglePostComments(
 	}
 
 	for _, commentEntry := range commentEntries {
-		glog.Infof("\nHere are the comment entries: %v \n", commentEntry)
+		glog.Infof("\nHere is the comment entry: %v \n", commentEntry.Body)
 		pkMapKey := lib.MakePkMapKey(commentEntry.PosterPublicKey)
 		// Remove comments that are blocked by either the reader or the poster of the root post
 		if _, ok := blockedPublicKeys[lib.PkToString(commentEntry.PosterPublicKey, fes.Params)]; !ok && profilePubKeyMap[pkMapKey] == nil {

--- a/routes/post.go
+++ b/routes/post.go
@@ -1002,6 +1002,14 @@ func (fes *APIServer) GetSinglePost(ww http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	if requestData.ThreadLevelLimit > 4 {
+		requestData.ThreadLevelLimit = 4
+	}
+
+	if requestData.CommentLimit > 30 {
+		requestData.CommentLimit = 30
+	}
+
 	// Decode the postHash.
 	postHash, err := GetPostHashFromPostHashHex(requestData.PostHashHex)
 	if err != nil {

--- a/routes/post.go
+++ b/routes/post.go
@@ -979,14 +979,14 @@ type GetSinglePostRequest struct {
 	CommentOffset              uint32 `safeForLogging:"true"`
 	CommentLimit               uint32 `safeForLogging:"true"`
 	ReaderPublicKeyBase58Check string `safeForLogging:"true"`
-	// How many reply-levels deep of comments will be retrieved. If unset, will only retrieve the top-level replies
+	// How many levels of replies will be retrieved. If unset, will only retrieve the top-level replies.
 	ThreadLevelLimit           uint32 `safeForLogging:"true"`
 	// How many child replies of a parent comment will be considered when returning a comment thread. Setting this to -1 will include all child replies. This limit does not affect the top-level replies to a post.
 	ThreadLeafLimit int32 `safeForLogging:"true"`
-	// If the post contains a comment thread where all comments are created by the author, include that thread in the response
+	// If the post contains a comment thread where all comments are created by the author, include that thread in the response.
 	LoadAuthorThread           bool   `safeForLogging:"true"`
 
-	// If set to true, then the posts in the response will contain a boolean about whether they're in the global feed
+	// If set to true, then the posts in the response will contain a boolean about whether they're in the global feed.
 	AddGlobalFeedBool bool `safeForLogging:"true"`
 }
 
@@ -1230,7 +1230,7 @@ func (fes *APIServer) GetSinglePost(ww http.ResponseWriter, req *http.Request) {
 	}
 }
 
-// Get the comments associated with a single post
+// Get the comments associated with a single post.
 func (fes *APIServer) GetSinglePostComments(
 	utxoView *lib.UtxoView,
 	pubKeyToProfileEntryResponseMap map[lib.PkMapKey]*ProfileEntryResponse,
@@ -1370,13 +1370,13 @@ func (fes *APIServer) GetSinglePostComments(
 	}
 
 	for ii, comment := range comments {
-		// If the previous stack was loading the comment author thread and the comment in question is from the same author, load it
+		// If the previous stack was loading the comment author thread and the comment in question is from the same author, load it.
 		loadCommentAuthorThread := loadAuthorThread && comment.PosterPublicKeyBase58Check == topLevelPosterPublicKeyBase58Check
-		// Only iterate over comments within the specified leaf-limit. To follow a single reply thread, that limit would be 1. All top-level replies are included. A limit of -1 includes all leafs
+		// Only iterate over comments within the specified leaf-limit. To follow a single reply thread, that limit would be 1. All top-level replies are included. A limit of -1 includes all leafs.
 		commentWithinLeafLimit := commentLevel == 0 || int32(ii) < requestData.ThreadLeafLimit || requestData.ThreadLeafLimit == -1
-		// Only recurse up to a certain depth. If we're within a thread chain consisting only of posts from the original post author, include all of the comments
+		// Only recurse up to a certain depth. If we're within a thread chain consisting only of posts from the original post author, include all of the comments.
 		commentWithinThreadLevelLimit := (commentLevel < requestData.ThreadLevelLimit || loadCommentAuthorThread)
-		// If this comment is within the leaf limit and isn't recursing too deeply, load the comment
+		// If this comment is within the leaf limit and isn't recursing too deeply, load the comment.
 		if commentWithinLeafLimit && commentWithinThreadLevelLimit {
 			commentReplies, err := fes.GetSinglePostComments(
 				utxoView,

--- a/routes/post.go
+++ b/routes/post.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"github.com/golang/glog"
 	"io"
 	"net/http"
 	"reflect"
@@ -1192,7 +1191,6 @@ func (fes *APIServer) GetSinglePost(ww http.ResponseWriter, req *http.Request) {
 		parentPostEntryResponseList = append(parentPostEntryResponseList, parentEntryResponse)
 	}
 
-	glog.Infof("\nGetting comments for: %v \n", postEntryResponse.Body)
 	comments, err := fes.GetSinglePostComments(
 		utxoView,
 		postEntryResponse,
@@ -1245,8 +1243,6 @@ func (fes *APIServer) GetSinglePostComments(
 	if err != nil {
 		return nil, err
 	}
-
-	glog.Infof("Fetched this many entries: %v", len(commentEntries))
 
 	// Process the comments into something we can return.
 	commentEntryResponseList := []*PostEntryResponse{}
@@ -1351,13 +1347,11 @@ func (fes *APIServer) GetSinglePostComments(
 		if commentProfileEntryResponse == nil || commentEntry.IsDeleted() ||
 			(commentEntry.IsHidden && commentEntry.CommentCount == 0) ||
 			(commentAuthorIsCurrentPoster && (isCurrentPosterBlocked || isCurrentPosterGreylisted)) {
-			glog.Infof("\nSkpping comment Empty: %v Deleted: %v Hidden: %v Blocked: %v\n", commentProfileEntryResponse == nil, commentEntry.IsDeleted(), (commentEntry.IsHidden && commentEntry.CommentCount == 0), (commentAuthorIsCurrentPoster && (isCurrentPosterBlocked || isCurrentPosterGreylisted)))
 			continue
 		}
 
 		// Build the comments entry response and append.
 		commentEntryResponse, err := fes._postEntryToResponse(commentEntry, requestData.AddGlobalFeedBool /*AddGlobalFeed*/, fes.Params, utxoView, readerPublicKeyBytes, 2)
-		glog.Infof("\nHere is the comment entry response: %v \n", commentEntryResponse.Body)
 		if err != nil {
 			return nil, err
 		}
@@ -1439,7 +1433,6 @@ func (fes *APIServer) GetSinglePostComments(
 	}
 
 	for ii, comment := range comments {
-		glog.Infof("\nIterating through the comment: %v \n", comment.Body)
 		// If the previous stack was loading the comment author thread and the comment in question is from the same author, load it.
 		loadCommentAuthorThread := loadAuthorThread && comment.PosterPublicKeyBase58Check == topLevelPosterPublicKeyBase58Check
 		// Only iterate over comments within the specified leaf-limit. To follow a single reply thread, that limit would be 1. All top-level replies are included. A limit of -1 includes all leafs.

--- a/routes/post.go
+++ b/routes/post.go
@@ -1372,7 +1372,7 @@ func (fes *APIServer) GetSinglePostComments(
 	}
 
 	for ii, comment := range comments {
-		glog.Infof("Iterating through comment: %v", comment.Body)
+		glog.Infof("Iterating through the comment: %v", comment.Body)
 		// If the previous stack was loading the comment author thread and the comment in question is from the same author, load it.
 		loadCommentAuthorThread := loadAuthorThread && comment.PosterPublicKeyBase58Check == topLevelPosterPublicKeyBase58Check
 		// Only iterate over comments within the specified leaf-limit. To follow a single reply thread, that limit would be 1. All top-level replies are included. A limit of -1 includes all leafs.

--- a/routes/post.go
+++ b/routes/post.go
@@ -1282,10 +1282,9 @@ func (fes *APIServer) GetSinglePostComments(
 		profileEntry := utxoView.GetProfileEntryForPublicKey(pubKeyBytes)
 		if profileEntry == nil {
 			continue
-		} else {
-			pubKeyToProfileEntryResponseMap[lib.MakePkMapKey(pubKeyBytes)] =
-				fes._profileEntryToResponse(profileEntry, utxoView)
 		}
+		pubKeyToProfileEntryResponseMap[lib.MakePkMapKey(pubKeyBytes)] =
+			fes._profileEntryToResponse(profileEntry, utxoView)
 	}
 
 	// If the profile that posted this post does not have a profile, return with error.

--- a/routes/post.go
+++ b/routes/post.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"github.com/golang/glog"
 	"io"
 	"net/http"
 	"reflect"
@@ -1196,6 +1197,7 @@ func (fes *APIServer) GetSinglePost(ww http.ResponseWriter, req *http.Request) {
 		parentPostEntryResponseList = append(parentPostEntryResponseList, parentEntryResponse)
 	}
 
+	glog.Infof("Getting comments for: %v", postEntryResponse.Body)
 	comments, err := fes.GetSinglePostComments(
 		utxoView,
 		pubKeyToProfileEntryResponseMap,
@@ -1370,6 +1372,7 @@ func (fes *APIServer) GetSinglePostComments(
 	}
 
 	for ii, comment := range comments {
+		glog.Infof("Iterating through comment: %v", comment.Body)
 		// If the previous stack was loading the comment author thread and the comment in question is from the same author, load it.
 		loadCommentAuthorThread := loadAuthorThread && comment.PosterPublicKeyBase58Check == topLevelPosterPublicKeyBase58Check
 		// Only iterate over comments within the specified leaf-limit. To follow a single reply thread, that limit would be 1. All top-level replies are included. A limit of -1 includes all leafs.

--- a/routes/post.go
+++ b/routes/post.go
@@ -1428,7 +1428,7 @@ func (fes *APIServer) GetSinglePostComments(
 	// Slice the comments from the offset up to either the end of the slice or the offset + limit, whichever is smaller.
 	maxIdx := lib.MinUint32(commentEntryResponseLength, requestData.CommentOffset+requestData.CommentLimit)
 	var comments []*PostEntryResponse
-	if commentEntryResponseLength > requestData.CommentOffset {
+	if commentEntryResponseLength > requestData.CommentOffset && commentLevel == 0 {
 		comments = commentEntryResponseList[requestData.CommentOffset:maxIdx]
 	}
 

--- a/routes/post.go
+++ b/routes/post.go
@@ -1288,6 +1288,7 @@ func (fes *APIServer) GetSinglePostComments(
 		if commentProfileEntryResponse == nil || commentEntry.IsDeleted() ||
 			(commentEntry.IsHidden && commentEntry.CommentCount == 0) ||
 			(commentAuthorIsCurrentPoster && (isCurrentPosterBlocked || isCurrentPosterGreylisted)) {
+			glog.Infof("\nSkpping comment Empty: %v Deleted: %v Hidden: %v Blocked: %v\n", commentProfileEntryResponse == nil, commentEntry.IsDeleted(), (commentEntry.IsHidden && commentEntry.CommentCount == 0), (commentAuthorIsCurrentPoster && (isCurrentPosterBlocked || isCurrentPosterGreylisted)))
 			continue
 		}
 

--- a/routes/post.go
+++ b/routes/post.go
@@ -1259,7 +1259,6 @@ func (fes *APIServer) GetSinglePostComments(
 		return nil, err
 	}
 
-	glog.Infof("\nHere are the comment entries: %v \n", commentEntries)
 	// Process the comments into something we can return.
 	commentEntryResponseList := []*PostEntryResponse{}
 	// Create a map from commentEntryPostHashHex to commentEntry to ease look up of public key bytes when sorting
@@ -1271,7 +1270,6 @@ func (fes *APIServer) GetSinglePostComments(
 	}
 
 	for _, commentEntry := range commentEntries {
-		glog.Infof("\nHere is the comment entry: %v \n", commentEntry.Body)
 		pkMapKey := lib.MakePkMapKey(commentEntry.PosterPublicKey)
 		// Remove comments that are blocked by either the reader or the poster of the root post
 		if _, ok := blockedPublicKeys[lib.PkToString(commentEntry.PosterPublicKey, fes.Params)]; !ok && profilePubKeyMap[pkMapKey] == nil {
@@ -1293,6 +1291,7 @@ func (fes *APIServer) GetSinglePostComments(
 
 		// Build the comments entry response and append.
 		commentEntryResponse, err := fes._postEntryToResponse(commentEntry, requestData.AddGlobalFeedBool /*AddGlobalFeed*/, fes.Params, utxoView, readerPublicKeyBytes, 2)
+		glog.Infof("\nHere is the comment entry response: %v \n", commentEntryResponse.Body)
 		if err != nil {
 			return nil, err
 		}

--- a/routes/post.go
+++ b/routes/post.go
@@ -1395,6 +1395,7 @@ func (fes *APIServer) GetSinglePostComments(
 	// Slice the comments from the offset up to either the end of the slice or the offset + limit, whichever is smaller.
 	maxIdx := lib.MinUint32(commentEntryResponseLength, requestData.CommentOffset+requestData.CommentLimit)
 	var comments []*CommentsPostEntryResponse
+	// Only apply the offset to top-level comments. CommentOffset & CommentLimit specify how top-level comments are loaded, ThreadLevelLimit & ThreadLeafLevelLimit specify how children comments should be loaded
 	if commentEntryResponseLength > requestData.CommentOffset && commentLevel == 0 {
 		comments = commentEntryResponseList[requestData.CommentOffset:maxIdx]
 	} else {

--- a/routes/post.go
+++ b/routes/post.go
@@ -1354,9 +1354,10 @@ func (fes *APIServer) GetSinglePostComments(
 		comments = commentEntryResponseList[requestData.CommentOffset:maxIdx]
 	}
 
+	// If we haven't yet reached the desired comment thread level, recurse one level deeper and retrieve comments for each comment.
 	if commentLevel < requestData.ThreadLevelLimit {
 		for _, comment := range comments {
-			fes.GetSinglePostComments(
+			commentReplies, err := fes.GetSinglePostComments(
 				commentEntries,
 				utxoView,
 				pubKeyToProfileEntryResponseMap,
@@ -1369,6 +1370,10 @@ func (fes *APIServer) GetSinglePostComments(
 				profilePubKeyMap,
 				blockedPublicKeys,
 				commentLevel + 1)
+			if err != nil {
+				return nil, err
+			}
+			comment.Comments = commentReplies
 		}
 	}
 

--- a/routes/post.go
+++ b/routes/post.go
@@ -1372,7 +1372,7 @@ func (fes *APIServer) GetSinglePostComments(
 	}
 
 	for ii, comment := range comments {
-		glog.Infof("Iterating through this comment: %v", comment.Body)
+		glog.Infof("Iterating through comment: %v", comment.Body)
 		// If the previous stack was loading the comment author thread and the comment in question is from the same author, load it.
 		loadCommentAuthorThread := loadAuthorThread && comment.PosterPublicKeyBase58Check == topLevelPosterPublicKeyBase58Check
 		// Only iterate over comments within the specified leaf-limit. To follow a single reply thread, that limit would be 1. All top-level replies are included. A limit of -1 includes all leafs.

--- a/scripts/nodes/n0_test
+++ b/scripts/nodes/n0_test
@@ -41,4 +41,5 @@ rm /tmp/main.*.log
   --secure-header-development=true \
   --block-cypher-api-key=092dae962ea44b02809a4c74408b42a1 \
   --min-satoshis-for-profile=0 \
+  --expose-global-state=true \
   --show-processing-spinners=true )

--- a/scripts/nodes/n0_test
+++ b/scripts/nodes/n0_test
@@ -41,5 +41,4 @@ rm /tmp/main.*.log
   --secure-header-development=true \
   --block-cypher-api-key=092dae962ea44b02809a4c74408b42a1 \
   --min-satoshis-for-profile=0 \
-  --expose-global-state=true \
   --show-processing-spinners=true )


### PR DESCRIPTION
This PR adds new parameters to the `get-single-post` route which enables nested comments to be returned from the route. It also splits out the getComments piece of the route into it's own helper function to facilitate the necessary recursion.

The 3 parameters added are:
`ThreadLevelLimit`: How many reply-levels deep of comments will be retrieved. If unset, will only retrieve the top-level replies. For example, if this is set to 2, the api will return all replies to the parent post, replies to those replies, and replies to those replies.
`ThreadLeafLimit`: How many child replies of a parent comment will be considered when returning a comment thread. Setting this to -1 will include all child replies. This limit does not affect the top-level replies to a post. If this were set to one, the API would return all replies to a post, the top reply to each of those replies, the top reply to each of those replies, etc. Reply ranking is done in the same way comments are currently ordered.
`LoadAuthorThread`: If the post contains a comment thread where all comments are created by the author, include that thread in the response. Often, when someone wants to create a long post, they will do so by creating a post, reply to that post with page 2, reply to that reply with page 3 of the response, etc. If this flag is set, this full thread would be returned by the API.