### PR TITLE
Fix bugs with Messages comparing PublicKey to byte slice

### DIFF
--- a/routes/message.go
+++ b/routes/message.go
@@ -513,6 +513,11 @@ func (fes *APIServer) SendMessageStateless(ww http.ResponseWriter, req *http.Req
 			"base58 public key %s: %v", requestData.RecipientPublicKeyBase58Check, err))
 		return
 	}
+	blockHeight := fes.blockchain.BlockTip().Height + 1
+	var baseGroupKeyName []byte
+	if blockHeight > fes.Params.ForkHeights.DeSoV3MessagesBlockHeight {
+		baseGroupKeyName = lib.BaseGroupKeyName()[:]
+	}
 
 	// Try and create the message for the user.
 	tstamp := uint64(time.Now().UnixNano())
@@ -520,8 +525,8 @@ func (fes *APIServer) SendMessageStateless(ww http.ResponseWriter, req *http.Req
 		senderPkBytes, recipientPkBytes,
 		requestData.MessageText,
 		requestData.EncryptedMessageText,
-		senderPkBytes, lib.BaseGroupKeyName()[:],
-		recipientPkBytes, lib.BaseGroupKeyName()[:],
+		senderPkBytes, baseGroupKeyName,
+		recipientPkBytes, baseGroupKeyName,
 		tstamp,
 		requestData.MinFeeRateNanosPerKB, fes.backendServer.GetMempool(), additionalOutputs)
 	if err != nil {

--- a/routes/message.go
+++ b/routes/message.go
@@ -400,7 +400,7 @@ func (fes *APIServer) getMessagesStateless(publicKeyBytes []byte,
 
 func (fes *APIServer) getOtherPartyInThread(messageEntry *lib.MessageEntry,
 	readerPublicKeyBytes []byte) (otherPartyPublicKeyBytes []byte, otherPartyPublicKeyBase58Check string) {
-	if reflect.DeepEqual(messageEntry.RecipientPublicKey, readerPublicKeyBytes) {
+	if reflect.DeepEqual(messageEntry.RecipientPublicKey[:], readerPublicKeyBytes) {
 		otherPartyPublicKeyBytes = messageEntry.SenderPublicKey[:]
 	} else {
 		otherPartyPublicKeyBytes = messageEntry.RecipientPublicKey[:]

--- a/routes/message.go
+++ b/routes/message.go
@@ -325,7 +325,7 @@ func (fes *APIServer) getMessagesStateless(publicKeyBytes []byte,
 			RecipientPublicKeyBase58Check: lib.PkToString(messageEntry.RecipientPublicKey[:], fes.Params),
 			EncryptedText:                 hex.EncodeToString(messageEntry.EncryptedText),
 			TstampNanos:                   messageEntry.TstampNanos,
-			IsSender:                      !reflect.DeepEqual(messageEntry.RecipientPublicKey, publicKeyBytes),
+			IsSender:                      !reflect.DeepEqual(messageEntry.RecipientPublicKey[:], publicKeyBytes),
 			V2:                            V2,
 		}
 		contactEntry, _ := contactMap[lib.PkToString(otherPartyPublicKeyBytes, fes.Params)]


### PR DESCRIPTION
- take bytes from RecipientPublicKey before comparison to compute IsSender
- fix comparison of publicKey to byte slice in getOtherPartyInThread