### PR TITLE
Enable proper decoding for extra data values

### DIFF
--- a/routes/exchange.go
+++ b/routes/exchange.go
@@ -557,8 +557,8 @@ func APITransactionToResponse(
 	if txnn.ExtraData != nil && len(txnn.ExtraData) > 0 {
 		ret.ExtraData = make(map[string]string)
 		for extraDataKey, extraDataValue := range txnn.ExtraData {
-			var decoderFunc = GetExtraDataDecoderFunc(extraDataKey)
-			ret.ExtraData[extraDataKey] = decoderFunc(extraDataValue)
+			var decoderFunc = GetExtraDataDecoder(extraDataKey)
+			ret.ExtraData[extraDataKey] = decoderFunc(extraDataValue, params)
 		}
 	}
 

--- a/routes/exchange.go
+++ b/routes/exchange.go
@@ -554,11 +554,11 @@ func APITransactionToResponse(
 			AmountNanos:          output.AmountNanos,
 		})
 	}
-
 	if txnn.ExtraData != nil && len(txnn.ExtraData) > 0 {
 		ret.ExtraData = make(map[string]string)
 		for extraDataKey, extraDataValue := range txnn.ExtraData {
-			ret.ExtraData[extraDataKey] = string(extraDataValue)
+			var decoderFunc = GetExtraDataDecoderFunc(extraDataKey)
+			ret.ExtraData[extraDataKey] = decoderFunc(extraDataValue)
 		}
 	}
 

--- a/routes/extra_data_utils.go
+++ b/routes/extra_data_utils.go
@@ -44,11 +44,11 @@ var ExtraDataKeyToDecoders = map[string]ExtraDataDecoder{
 // in transaction may have special encoding. In such cases
 // we'll need specialized decoders too
 func GetExtraDataDecoder(txnType lib.TxnType, key string) ExtraDataDecoder {
-	if txnType == lib.TxnTypeSubmitPost {
-		return DecodeString
-	}
 	if decoder, exists := ExtraDataKeyToDecoders[key]; exists {
 		return decoder
+	}
+	if txnType == lib.TxnTypeSubmitPost {
+		return DecodeString
 	}
 	// Default, just return hex encoding for bytes
 	return DecodeHexString

--- a/routes/extra_data_utils.go
+++ b/routes/extra_data_utils.go
@@ -1,0 +1,38 @@
+package routes
+
+import (
+	"encoding/hex"
+	"github.com/deso-protocol/core/lib"
+	"strconv"
+)
+
+type DecoderFunc func([]byte) string
+
+type ExtraDataDecoder struct {
+	Key     string
+	Decoder DecoderFunc
+}
+
+// GetExtraDataDecoderFunc Values in ExtraData field
+// in transaction may have special encoding. In such cases
+// we'll need specialized decoders too
+func GetExtraDataDecoderFunc(key string) DecoderFunc {
+	var decoders = []ExtraDataDecoder{
+		{
+			lib.DiamondLevelKey,
+			ByteArrTo64BitInt,
+		},
+	}
+	for _, decoder := range decoders {
+		if decoder.Key == key {
+			return decoder.Decoder
+		}
+	}
+	// Default, just return hex encoding for bytes
+	return hex.EncodeToString
+}
+
+func ByteArrTo64BitInt(bytes []byte) string {
+	var decoded, _ = lib.Varint(bytes)
+	return strconv.FormatInt(decoded, 10)
+}

--- a/routes/extra_data_utils.go
+++ b/routes/extra_data_utils.go
@@ -10,7 +10,7 @@ import (
 type ExtraDataDecoder func([]byte, *lib.DeSoParams) string
 
 var ExtraDataKeyToDecoders = map[string]ExtraDataDecoder{
-	lib.RepostedPostHash:  DecodePkToString,
+	lib.RepostedPostHash:  DecodeHexString,
 	lib.IsQuotedRepostKey: DecodeBoolString,
 
 	lib.USDCentsPerBitcoinKey:      Decode64BitUintString,

--- a/routes/extra_data_utils.go
+++ b/routes/extra_data_utils.go
@@ -29,7 +29,7 @@ var ExtraDataKeyToDecoders = map[string]ExtraDataDecoder{
 	lib.MessagingPublicKey:             DecodePkToString,
 	lib.SenderMessagingPublicKey:       DecodePkToString,
 	lib.SenderMessagingGroupKeyName:    DecodeString,
-	lib.RecipientMessagingPublicKey:    DecodeHexString,
+	lib.RecipientMessagingPublicKey:    DecodePkToString,
 	lib.RecipientMessagingGroupKeyName: DecodeString,
 
 	lib.DESORoyaltiesMapKey: DecodePubKeyToUint64MapString,


### PR DESCRIPTION
Values in the ExtraData field can be encoded in different ways. The decoding needs to match the encoding used for each field.
Before:
```
"ExtraData": {
                "DiamondLevel": "\u0002",
                "DiamondPostHash": "~\ufffd+v\u2c45\u0010p\ufffdt\u000e%\ufffd\ufffd\fd\ufffd(\ufffd&\ufffd\ufffd\ufffdsO\u0019\u04fa\u0282$"
            },
```

After:
```
"ExtraData": {
                "DiamondLevel": "1",
                "DiamondPostHash": "7eba2b76e2b1851070f2740e25c1c70c64a228e226f0dff5734f19d3baca8224"
            },
```