### PR TITLE
Include the AcceptedBlockHeight in the BidEntryResponse if it exists

### DIFF
--- a/routes/nft.go
+++ b/routes/nft.go
@@ -58,6 +58,9 @@ type NFTBidEntryResponse struct {
 	HighestBidAmountNanos *uint64 `json:",omitempty"`
 	LowestBidAmountNanos  *uint64 `json:",omitempty"`
 
+	// If we fetched the accepted bid history, include the accepted block height.
+	AcceptedBlockHeight *uint32 `json:",omitempty"`
+
 	// Current balance of this bidder.
 	BidderBalanceNanos uint64
 }
@@ -1482,6 +1485,7 @@ func (fes *APIServer) _bidEntryToResponse(bidEntry *lib.NFTBidEntry, postEntryRe
 
 		HighestBidAmountNanos: highBid,
 		LowestBidAmountNanos:  lowBid,
+		AcceptedBlockHeight:   bidEntry.AcceptedBlockHeight,
 		BidderBalanceNanos:    bidderBalanceNanos,
 	}
 }


### PR DESCRIPTION
Depends on https://github.com/deso-protocol/core/pull/224