### PR TITLE
return transactions from db in api/v0/get-txn/ endpoint

### DIFF
--- a/routes/transaction.go
+++ b/routes/transaction.go
@@ -57,8 +57,7 @@ func (fes *APIServer) GetTxn(ww http.ResponseWriter, req *http.Request) {
 	}
 
 	txnFound := fes.mempool.IsTransactionInPool(txnHash)
-	// Only check DB in testnet for now.
-	if !txnFound && fes.Params.NetworkType == lib.NetworkType_TESTNET {
+	if !txnFound {
 		txnFound = lib.DbCheckTxnExistence(fes.TXIndex.TXIndexChain.DB(), txnHash)
 	}
 	res := &GetTxnResponse{


### PR DESCRIPTION
The endpoint only checks for transactions in the mempool. It needs to check the db as well to find older transactions.