### PR TITLE
Conversion of DAO coin limit order exchange rates and quantities from float64 <-> uint256

### DIFF
--- a/routes/dao_coin_exchange.go
+++ b/routes/dao_coin_exchange.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/deso-protocol/core/lib"
+	"github.com/golang/glog"
 	"github.com/holiman/uint256"
 	"github.com/pkg/errors"
 	"io"
@@ -241,6 +242,10 @@ func (fes *APIServer) buildDAOCoinLimitOrderResponsesForTransactor(
 			order,
 		)
 		if err != nil {
+			glog.Errorf(
+				"buildDAOCoinLimitOrderResponsesForTransactor: Unable to build DAO coin limit order response for limit order with OrderID: %v",
+				order.OrderID,
+			)
 			continue
 		}
 
@@ -317,7 +322,7 @@ func CalculateScaledExchangeRate(
 	if err != nil {
 		return nil, err
 	}
-	if rawScaledExchangeRate.Eq(uint256.NewInt().SetUint64(0)) {
+	if rawScaledExchangeRate.IsZero() {
 		return nil, errors.Errorf("The float value %f is too small to produce a scaled exchange rate", exchangeRateCoinsToSellPerCoinToBuy)
 	}
 	if buyingCoinPublicKeyBase58CheckOrUsername == "" {
@@ -331,7 +336,7 @@ func CalculateScaledExchangeRate(
 	} else if sellingCoinPublicKeyBase58CheckOrUsername == "" {
 		// Selling coin is $DESO
 		quotient := uint256.NewInt().Div(rawScaledExchangeRate, getDESOToDAOCoinBaseUnitsScalingFactor())
-		if quotient.Eq(uint256.NewInt().SetUint64(0)) {
+		if quotient.IsZero() {
 			return nil, errors.Errorf("The float value %f is too small to produce a scaled exchange rate", exchangeRateCoinsToSellPerCoinToBuy)
 		}
 		return quotient, nil

--- a/routes/dao_coin_exchange.go
+++ b/routes/dao_coin_exchange.go
@@ -299,10 +299,10 @@ func calculateFloatExchangeRate(scaledValue *uint256.Int) float64 {
 	return quotientFloat
 }
 
-// calculate (quantityInBaseUnits * 10^9)
+// calculate (quantityInBaseUnits * 10^18)
 func calculateQuantityToFillAsFloat(quantityInBaseUnits *uint256.Int) float64 {
 	quantityInBaseUnitsAsBigFloat := big.NewFloat(0).SetInt(quantityInBaseUnits.ToBig())
-	divisor := big.NewFloat(float64(lib.NanosPerUnit))
+	divisor := big.NewFloat(0).SetInt(lib.BaseUnitsPerCoin.ToBig())
 	quotientAsBigFloat := big.NewFloat(0).Quo(
 		quantityInBaseUnitsAsBigFloat,
 		divisor,
@@ -311,9 +311,9 @@ func calculateQuantityToFillAsFloat(quantityInBaseUnits *uint256.Int) float64 {
 	return quotient
 }
 
-// calculate (quantityInBaseUnits / 10^9)
+// calculate (quantityInBaseUnits / 10^18)
 func calculateQuantityToFillAsBaseUnits(quantityToFill float64) (*uint256.Int, error) {
-	multiplier := big.NewFloat(float64(lib.NanosPerUnit))
+	multiplier := big.NewFloat(0).SetInt(lib.BaseUnitsPerCoin.ToBig())
 	product := big.NewFloat(0).Mul(
 		big.NewFloat(quantityToFill),
 		multiplier,

--- a/routes/dao_coin_exchange.go
+++ b/routes/dao_coin_exchange.go
@@ -470,7 +470,7 @@ func calculateQuantityToFillToBaseUnitsWithScalingFactor(
 	)
 }
 
-// isCoinToFillDESO given a buying coin, selling coin, and operation type, this determines if the QuantityToFill field
+// given a buying coin, selling coin, and operation type, this determines if the QuantityToFill field
 // for the coin the quantity field refers to is $DESO. If it's not $DESO, then it's assumed to be a DAO coin
 func isCoinToFillDESO(
 	buyingCoinPublicKeyBase58CheckOrUsername string,

--- a/routes/dao_coin_exchange_test.go
+++ b/routes/dao_coin_exchange_test.go
@@ -1,0 +1,242 @@
+package routes
+
+import (
+	"github.com/deso-protocol/core/lib"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+	"math"
+	"testing"
+)
+
+const (
+	desoPubKeyBase58Check    = ""                  // represents $DESO
+	daoCoinPubKeyBase58Check = "TestDAOCoinPubKey" // represents valid DAO coin public key
+)
+
+func TestCalculateScaledExchangeRate(t *testing.T) {
+	// scaling factor = 1e18 / 1e9
+	desoToDaoCoinBaseUnitsScalingFactor := getDESOToDAOCoinBaseUnitsScalingFactor()
+
+	exchangeRate := 100.00000001
+	// equivalent to 100.00000001
+	expectedScaledExchangeRate := uint256.NewInt().Add(
+		uint256.NewInt().Mul(lib.OneE38, uint256.NewInt().SetUint64(100)),       // 100
+		uint256.NewInt().Div(lib.OneE38, uint256.NewInt().SetUint64(100000000)), // 0.00000001
+	)
+
+	// Test successful scaling when buying coin is a DAO coin, and selling coin is a DAO coin order. Exchange rate should be 1e38
+	{
+		scaledExchangeRate, err := CalculateScaledExchangeRate(
+			daoCoinPubKeyBase58Check,
+			daoCoinPubKeyBase58Check,
+			exchangeRate,
+		)
+		require.NoError(t, err)
+		require.Equal(t, expectedScaledExchangeRate, scaledExchangeRate)
+	}
+
+	// Test successful scaling when buying coin is a DAO coin, and selling coin  is $DESO. Exchange rate should be 1e38 / 1e9
+	{
+		scaledExchangeRate, err := CalculateScaledExchangeRate(
+			daoCoinPubKeyBase58Check,
+			desoPubKeyBase58Check,
+			exchangeRate,
+		)
+		require.NoError(t, err)
+		expectedScaledExchangeRate := uint256.NewInt().Div(expectedScaledExchangeRate, desoToDaoCoinBaseUnitsScalingFactor)
+		require.Equal(t, expectedScaledExchangeRate, scaledExchangeRate)
+	}
+
+	// Test successful scaling when buying coin is $DESO coin, and buying coin is $DESO. Exchange rate should be 1e38 * 1e9
+	{
+		scaledExchangeRate, err := CalculateScaledExchangeRate(
+			desoPubKeyBase58Check,
+			daoCoinPubKeyBase58Check,
+			exchangeRate,
+		)
+		require.NoError(t, err)
+		expectedScaledExchangeRate := uint256.NewInt().Mul(
+			expectedScaledExchangeRate,
+			desoToDaoCoinBaseUnitsScalingFactor,
+		)
+		require.Equal(t, expectedScaledExchangeRate, scaledExchangeRate)
+	}
+
+	// Test failed scaling when buying coin is a DAO coin, selling coin  is $DESO, but exchange rate is too small
+	{
+		exchangeRate := 0.0000000000000000000000000000001 // 1e-31
+		_, err := CalculateScaledExchangeRate(
+			daoCoinPubKeyBase58Check,
+			desoPubKeyBase58Check,
+			exchangeRate,
+		)
+		require.Error(t, err) // expected to fail because the resulting value 1e-39 is too small to be represented
+	}
+
+	// Test failed scaling when buying coin is a DAO coin, selling coin  is $DESO, but exchange rate is too small
+	{
+		exchangeRate := math.Exp(260)
+		_, err := CalculateScaledExchangeRate(
+			daoCoinPubKeyBase58Check,
+			desoPubKeyBase58Check,
+			exchangeRate,
+		)
+		require.Error(t, err) // expected to fail because 2^260 overflows
+	}
+}
+
+func TestCalculateExchangeRateAsFloat(t *testing.T) {
+	// scaling factor = 1e18 / 1e9
+	desoToDaoCoinBaseUnitsScalingFactor := getDESOToDAOCoinBaseUnitsScalingFactor()
+
+	// equivalent to 100.00000001
+	scaledExchangeRate := uint256.NewInt().Add(
+		uint256.NewInt().Mul(lib.OneE38, uint256.NewInt().SetUint64(100)),       // 100
+		uint256.NewInt().Div(lib.OneE38, uint256.NewInt().SetUint64(100000000)), // 0.00000001
+	)
+	expectedExchangeRate := 100.00000001
+
+	// Test when buying coin is a DAO coin, and selling coin is a DAO coin order. Exchange rate should be 1
+	{
+		scaledValue, err := CalculateExchangeRateAsFloat(
+			daoCoinPubKeyBase58Check,
+			daoCoinPubKeyBase58Check,
+			scaledExchangeRate,
+		)
+		require.NoError(t, err)
+		require.Equal(t, expectedExchangeRate, scaledValue)
+	}
+
+	// Test when buying coin is a DAO coin, and selling coin  is $DESO. Exchange rate should be 1e9
+	{
+		scaledExchangeRate, err := CalculateExchangeRateAsFloat(
+			daoCoinPubKeyBase58Check,
+			desoPubKeyBase58Check,
+			scaledExchangeRate,
+		)
+		require.NoError(t, err)
+		expectedReScaledExchangeRate := expectedExchangeRate * float64(desoToDaoCoinBaseUnitsScalingFactor.Uint64())
+		require.Equal(t, expectedReScaledExchangeRate, scaledExchangeRate)
+	}
+
+	// Test when buying coin is $DESO coin, and buying coin is $DESO. Exchange rate should be 1e-9
+	{
+		scaledExchangeRate, err := CalculateExchangeRateAsFloat(
+			desoPubKeyBase58Check,
+			daoCoinPubKeyBase58Check,
+			scaledExchangeRate,
+		)
+		require.NoError(t, err)
+		expectedReScaledExchangeRate := expectedExchangeRate / float64(desoToDaoCoinBaseUnitsScalingFactor.Uint64())
+		require.Equal(t, expectedReScaledExchangeRate, scaledExchangeRate)
+	}
+}
+
+func TestCalculateQuantityToFillAsBaseUnits(t *testing.T) {
+	expectedValueIfDESO := uint256.NewInt().SetUint64(lib.NanosPerUnit)
+	expectedValueIfDAOCoin := &(*lib.BaseUnitsPerCoin)
+
+	quantity := float64(1)
+
+	// Bid order to buy $DESO using a DAO coin
+	{
+		scaledQuantity, err := CalculateQuantityToFillAsBaseUnits(
+			desoPubKeyBase58Check,
+			daoCoinPubKeyBase58Check,
+			DAOCoinLimitOrderOperationTypeStringBID,
+			quantity,
+		)
+		require.NoError(t, err)
+		require.Equal(t, expectedValueIfDESO, scaledQuantity)
+	}
+
+	// Bid order to buy DAO coin using $DESO
+	{
+		scaledQuantity, err := CalculateQuantityToFillAsBaseUnits(
+			daoCoinPubKeyBase58Check,
+			desoPubKeyBase58Check,
+			DAOCoinLimitOrderOperationTypeStringBID,
+			quantity,
+		)
+		require.NoError(t, err)
+		require.Equal(t, expectedValueIfDAOCoin, scaledQuantity)
+	}
+
+	// Ask order to sell $DESO for a DAO coin
+	{
+		scaledQuantity, err := CalculateQuantityToFillAsBaseUnits(
+			daoCoinPubKeyBase58Check,
+			desoPubKeyBase58Check,
+			DAOCoinLimitOrderOperationTypeStringASK,
+			quantity,
+		)
+		require.NoError(t, err)
+		require.Equal(t, expectedValueIfDESO, scaledQuantity)
+	}
+
+	// Ask order to sell DAO coin for $DESO
+	{
+		scaledQuantity, err := CalculateQuantityToFillAsBaseUnits(
+			desoPubKeyBase58Check,
+			daoCoinPubKeyBase58Check,
+			DAOCoinLimitOrderOperationTypeStringASK,
+			quantity,
+		)
+		require.NoError(t, err)
+		require.Equal(t, expectedValueIfDAOCoin, scaledQuantity)
+	}
+}
+
+func TestCalculateQuantityToFillAsFloat(t *testing.T) {
+	scaledQuantity := lib.BaseUnitsPerCoin
+	expectedValueIfDESO := float64(getDESOToDAOCoinBaseUnitsScalingFactor().Uint64()) // 1e9
+	expectedValueIfDAOCoin := float64(1)
+
+	// Bid order to buy $DESO using a DAO coin
+	{
+		quantity, err := CalculateQuantityToFillAsFloat(
+			desoPubKeyBase58Check,
+			daoCoinPubKeyBase58Check,
+			DAOCoinLimitOrderOperationTypeStringBID,
+			scaledQuantity,
+		)
+		require.NoError(t, err)
+		require.Equal(t, expectedValueIfDESO, quantity)
+	}
+
+	// Bid order to buy DAO coin using $DESO
+	{
+		quantity, err := CalculateQuantityToFillAsFloat(
+			daoCoinPubKeyBase58Check,
+			desoPubKeyBase58Check,
+			DAOCoinLimitOrderOperationTypeStringBID,
+			scaledQuantity,
+		)
+		require.NoError(t, err)
+		require.Equal(t, expectedValueIfDAOCoin, quantity)
+	}
+
+	// Ask order to sell $DESO for a DAO coin
+	{
+		quantity, err := CalculateQuantityToFillAsFloat(
+			daoCoinPubKeyBase58Check,
+			desoPubKeyBase58Check,
+			DAOCoinLimitOrderOperationTypeStringASK,
+			scaledQuantity,
+		)
+		require.NoError(t, err)
+		require.Equal(t, expectedValueIfDESO, quantity)
+	}
+
+	// Ask order to sell DAO coin for $DESO
+	{
+		quantity, err := CalculateQuantityToFillAsFloat(
+			desoPubKeyBase58Check,
+			daoCoinPubKeyBase58Check,
+			DAOCoinLimitOrderOperationTypeStringASK,
+			scaledQuantity,
+		)
+		require.NoError(t, err)
+		require.Equal(t, expectedValueIfDAOCoin, quantity)
+	}
+}

--- a/routes/transaction.go
+++ b/routes/transaction.go
@@ -2603,9 +2603,18 @@ func (fes *APIServer) CreateDAOCoinLimitOrder(ww http.ResponseWriter, req *http.
 		)
 		return
 	}
-	scaledExchangeRateCoinsToSellPerCoinToBuy, err := lib.CalculateScaledExchangeRate(
+	scaledExchangeRateCoinsToSellPerCoinToBuy, err := CalculateScaledExchangeRate(
+		requestData.BuyingDAOCoinCreatorPublicKeyBase58CheckOrUsername,
+		requestData.SellingDAOCoinCreatorPublicKeyBase58CheckOrUsername,
 		requestData.ExchangeRateCoinsToSellPerCoinToBuy,
 	)
+	if err != nil {
+		_AddBadRequestError(ww, fmt.Sprintf("CreateDAOCoinLimitOrder: %v", err))
+		return
+	}
+
+	// Validate operation type
+	operationType, err := orderOperationTypeToUint64(requestData.OperationType)
 	if err != nil {
 		_AddBadRequestError(ww, fmt.Sprintf("CreateDAOCoinLimitOrder: %v", err))
 		return
@@ -2616,16 +2625,13 @@ func (fes *APIServer) CreateDAOCoinLimitOrder(ww http.ResponseWriter, req *http.
 		_AddBadRequestError(ww, fmt.Sprint("CreateDAOCoinLimitOrder: QuantityToFill must be greater than 0"))
 		return
 	}
-	quantityToFillInBaseUnits, err := calculateQuantityToFillAsBaseUnits(
+
+	quantityToFillInBaseUnits, err := CalculateQuantityToFillAsBaseUnits(
+		requestData.BuyingDAOCoinCreatorPublicKeyBase58CheckOrUsername,
+		requestData.SellingDAOCoinCreatorPublicKeyBase58CheckOrUsername,
+		requestData.OperationType,
 		requestData.QuantityToFill,
 	)
-	if err != nil {
-		_AddBadRequestError(ww, fmt.Sprintf("CreateDAOCoinLimitOrder: %v", err))
-		return
-	}
-
-	// Validate operation type
-	operationType, err := orderOperationTypeToUint64(requestData.OperationType)
 	if err != nil {
 		_AddBadRequestError(ww, fmt.Sprintf("CreateDAOCoinLimitOrder: %v", err))
 		return
@@ -2706,21 +2712,25 @@ func (fes *APIServer) CreateDAOCoinMarketOrder(ww http.ResponseWriter, req *http
 		return
 	}
 
-	// Validate and convert quantity to base units
-	if requestData.QuantityToFill <= 0 {
-		_AddBadRequestError(ww, fmt.Sprint("CreateDAOCoinMarketOrder: QuantityToFill must be greater than 0"))
-		return
-	}
-	quantityToFillInBaseUnits, err := calculateQuantityToFillAsBaseUnits(
-		requestData.QuantityToFill,
-	)
+	// Validate operation type
+	operationType, err := orderOperationTypeToUint64(requestData.OperationType)
 	if err != nil {
 		_AddBadRequestError(ww, fmt.Sprintf("CreateDAOCoinMarketOrder: %v", err))
 		return
 	}
 
-	// Validate operation type
-	operationType, err := orderOperationTypeToUint64(requestData.OperationType)
+	// Validate and convert quantity to base units
+	if requestData.QuantityToFill <= 0 {
+		_AddBadRequestError(ww, fmt.Sprint("CreateDAOCoinMarketOrder: QuantityToFill must be greater than 0"))
+		return
+	}
+
+	quantityToFillInBaseUnits, err := CalculateQuantityToFillAsBaseUnits(
+		requestData.BuyingDAOCoinCreatorPublicKeyBase58CheckOrUsername,
+		requestData.SellingDAOCoinCreatorPublicKeyBase58CheckOrUsername,
+		requestData.OperationType,
+		requestData.QuantityToFill,
+	)
 	if err != nil {
 		_AddBadRequestError(ww, fmt.Sprintf("CreateDAOCoinMarketOrder: %v", err))
 		return


### PR DESCRIPTION
The API converts exchange rates and quantities back and forth from the float64 values provided by clients to the uint256 values used in core. This PR adds proper handing for back and forth conversions between the two.

Exchange rate field:
- If an order is buying a DAO coin and selling $DESO, we scale down the exchange rate by (1e38 * 1e-9) to account for the fact that 1 $DESO is equal to 1e9 nanos whereas 1 DAO coin is equal to 1e18 base units
- If an order is buying $DESO and selling a DAO coin, then we scale the exchange rate by (1e38 * 1e9) for the same reason
- If an order is buying and selling $DAO coins, we scale by 1e38 only

The quantity field:
- If the quantity field refers to $DESO, then we use 1e9 for scaling float coin quantities to uint256 $DESO nanos
- If the quantity field refers to a DAO coin, we use 1e18 for scaling float coin quantities to uint256 DAO coin base units

These rules ensure that the exchange rates and quantities that core deals are always in base units, and the API does the leg work of properly interpreting them into float values for clients.