### PR TITLE
Fix GetAcceptedBidHistory

### DIFF
--- a/routes/nft.go
+++ b/routes/nft.go
@@ -2162,6 +2162,9 @@ func (fes *APIServer) GetAcceptedBidHistory(ww http.ResponseWriter, req *http.Re
 		}
 		var acceptedBidEntryResponses []*NFTBidEntryResponse
 		for _, acceptedBidEntry := range *acceptedBidEntries {
+			if acceptedBidEntry == nil {
+				continue
+			}
 			acceptedBidEntryResponses = append(acceptedBidEntryResponses,
 				fes._bidEntryToResponse(
 					acceptedBidEntry, nil, utxoView, false, false))


### PR DESCRIPTION
Currently core may return some nil BidEntries when getting the accepted bid history. This should no longer happen after https://github.com/deso-protocol/core/pull/357 goes in, but this check will help prevent future issues as well.