### PR TITLE
Tgs/hot feed updates

### DIFF
--- a/routes/hot_feed.go
+++ b/routes/hot_feed.go
@@ -525,7 +525,7 @@ func (fes *APIServer) PopulateHotnessInfoMap(
 		glog.Errorf("Error getting mempool transactions: %v", err)
 	} else if len(txnsFromMempoolOrderedByTime) > 0 {
 		hotnessInfoBlocks = append(hotnessInfoBlocks, &HotnessInfoBlock{
-			Block:    &lib.MsgDeSoBlock{
+			Block: &lib.MsgDeSoBlock{
 				Txns: txnsFromMempoolOrderedByTime,
 			},
 			BlockAge: mempoolBlockHeight,

--- a/routes/hot_feed.go
+++ b/routes/hot_feed.go
@@ -542,6 +542,7 @@ func (fes *APIServer) PopulateHotnessInfoMap(
 
 	// Create new "block" for mempool txns, give it a block age of 1 greater than the current tip
 	dbMempoolTxnsOrderedByTime, err := lib.DbGetAllMempoolTxnsSortedByTimeAdded(utxoView.Handle)
+	glog.Infof("Here is the db mempool txns: %v, height: %v, error? %v", len(dbMempoolTxnsOrderedByTime), mempoolBlockHeight, err)
 
 	if err != nil {
 		glog.Errorf("Error getting mempool transactions: %v", err)

--- a/routes/hot_feed.go
+++ b/routes/hot_feed.go
@@ -417,10 +417,10 @@ func (fes *APIServer) UpdateHotFeedOrderedList(
 		}
 	}
 	glog.Info("UpdateHotFeedOrderedList: Looped through block nodes")
-	if (!foundNewConstants && blockTip.Height <= fes.HotFeedBlockHeight) ||
-		chainState != lib.SyncStateFullyCurrent || !chainFullyStored {
-		return nil
-	}
+	//if (!foundNewConstants && blockTip.Height <= fes.HotFeedBlockHeight) ||
+	//	chainState != lib.SyncStateFullyCurrent || !chainFullyStored {
+	//	return nil
+	//}
 
 	// Log how long this routine takes, since it could be heavy.
 	glog.Infof("UpdateHotFeedOrderedList: Starting new update cycle.")
@@ -542,7 +542,7 @@ func (fes *APIServer) PopulateHotnessInfoMap(
 
 	// Create new "block" for mempool txns, give it a block age of 1 greater than the current tip
 	dbMempoolTxnsOrderedByTime, err := lib.DbGetAllMempoolTxnsSortedByTimeAdded(utxoView.Handle)
-	
+
 	if err != nil {
 		glog.Infof("Error getting mempool transactions: %v", err)
 	} else if len(dbMempoolTxnsOrderedByTime) > 0 {

--- a/routes/hot_feed.go
+++ b/routes/hot_feed.go
@@ -301,7 +301,7 @@ func (fes *APIServer) UpdateHotFeedOrderedList(
 ) (_hotFeedPostsMap map[lib.BlockHash]*HotnessPostInfo,
 ) {
 	// Check to see if any of the algorithm constants have changed.
-	foundNewConstants := false
+	//foundNewConstants := false
 	globalStateInteractionCap, globalStateTagInteractionCap, globalStateTimeDecayBlocks, globalStateTagTimeDecayBlocks, globalStateTxnTypeMultiplierMap, err := fes.GetHotFeedConstantsFromGlobalState()
 	if err != nil {
 		glog.Infof("UpdateHotFeedOrderedList: ERROR - Failed to get constants: %v", err)
@@ -309,7 +309,7 @@ func (fes *APIServer) UpdateHotFeedOrderedList(
 	}
 	if globalStateInteractionCap == 0 || globalStateTimeDecayBlocks == 0 {
 		// The hot feed go routine has not been run yet since constants have not been set.
-		foundNewConstants = true
+		//foundNewConstants = true
 		// Set the default constants in GlobalState and then on the server object.
 		err := fes.GlobalState.Put(
 			_GlobalStatePrefixForHotFeedInteractionCap,
@@ -353,7 +353,7 @@ func (fes *APIServer) UpdateHotFeedOrderedList(
 		// Check to see if only the tag-specific feed configuration variables are unset and set just those.
 	} else if globalStateTagInteractionCap == 0 || globalStateTagTimeDecayBlocks == 0 {
 		// The hot feed go routine has not been run yet since constants have not been set.
-		foundNewConstants = true
+		//foundNewConstants = true
 		err = fes.GlobalState.Put(
 			_GlobalStatePrefixForHotFeedTagInteractionCap,
 			lib.EncodeUint64(DefaultHotFeedTagInteractionCap),
@@ -385,10 +385,10 @@ func (fes *APIServer) UpdateHotFeedOrderedList(
 		fes.HotFeedTagInteractionCap = globalStateTagInteractionCap
 		fes.HotFeedTagTimeDecayBlocks = globalStateTagTimeDecayBlocks
 		fes.HotFeedTxnTypeMultiplierMap = globalStateTxnTypeMultiplierMap
-		foundNewConstants = true
+		//foundNewConstants = true
 	} else if fes.HotFeedPostMultiplierUpdated || fes.HotFeedPKIDMultiplierUpdated {
 		// If a post's multiplier was updated, we need to recompute scores.
-		foundNewConstants = true
+		//foundNewConstants = true
 		fes.HotFeedPostMultiplierUpdated = false
 		fes.HotFeedPKIDMultiplierUpdated = false
 	}
@@ -396,7 +396,7 @@ func (fes *APIServer) UpdateHotFeedOrderedList(
 	// If the constants for the algorithm haven't changed and we have already seen the latest
 	// block or the chain is out of sync, bail.
 	blockTip := fes.blockchain.BlockTip()
-	chainState := fes.blockchain.ChainState()
+	//chainState := fes.blockchain.ChainState()
 
 	// This offset allows us to see what the hot feed would look like in the past,
 	// which is useful for testing purposes.
@@ -405,16 +405,16 @@ func (fes *APIServer) UpdateHotFeedOrderedList(
 	// Grab the last 15 days worth of blocks (25,920 blocks @ 5min/block).
 	lookbackWindowBlocks := 15 * 24 * 60 / 5
 	// Check if the most recent blocks that we'll be considering in hot feed computation have been processed.
-	chainFullyStored := true
+	//chainFullyStored := true
 	for _, blockNode := range fes.blockchain.BestChain() {
 		if blockNode.Height < blockTip.Height-uint32(lookbackWindowBlocks+blockOffsetForTesting) {
 			continue
 		}
 
-		if !blockNode.Status.IsFullyProcessed() {
-			chainFullyStored = false
-			break
-		}
+		//if !blockNode.Status.IsFullyProcessed() {
+		//	chainFullyStored = false
+		//	break
+		//}
 	}
 	glog.Info("UpdateHotFeedOrderedList: Looped through block nodes")
 	//if (!foundNewConstants && blockTip.Height <= fes.HotFeedBlockHeight) ||
@@ -609,7 +609,7 @@ func (fes *APIServer) PopulateHotnessInfoMap(
 			// Evaluate the txn and attempt to update the hotnessInfoMap.
 			postHashScored, interactionPKID, txnHotnessScore :=
 				fes.GetHotnessScoreInfoForTxn(txn, postBlockAge, postInteractionMap, utxoView, isTagFeed)
-			if txnHotnessScore != 0 && postHashScored != nil {
+			if postHashScored != nil {
 				// Check for a post-specific multiplier.
 				multiplier, hasMultiplier := postsToMultipliers[*postHashScored]
 				if hasMultiplier && multiplier >= 0 {

--- a/routes/hot_feed.go
+++ b/routes/hot_feed.go
@@ -82,7 +82,7 @@ func (fes *APIServer) StartHotFeedRoutine() {
 	out:
 		for {
 			select {
-			case <-time.After(5 * time.Minute):
+			case <-time.After(30 * time.Second):
 				resetCache := false
 				if cacheResetCounter >= ResetCachesIterationLimit {
 					resetCache = true
@@ -398,7 +398,7 @@ func (fes *APIServer) UpdateHotFeedOrderedList(
 	blockOffsetForTesting := 0
 
 	// Grab the last 90 days worth of blocks (25,920 blocks @ 5min/block).
-	lookbackWindowBlocks := 90 * 24 * 60 / 5
+	lookbackWindowBlocks := 15 * 24 * 60 / 5
 	// Check if the most recent blocks that we'll be considering in hot feed computation have been processed.
 	chainFullyStored := true
 	for _, blockNode := range fes.blockchain.BestChain() {

--- a/routes/hot_feed.go
+++ b/routes/hot_feed.go
@@ -392,7 +392,7 @@ func (fes *APIServer) UpdateHotFeedOrderedList(
 	// which is useful for testing purposes.
 	blockOffsetForTesting := 0
 
-	// Grab the last 15 days worth of blocks (25,920 blocks @ 5min/block).
+	// Grab the last 60 days worth of blocks (25,920 blocks @ 5min/block).
 	lookbackWindowBlocks := 60 * 24 * 60 / 5
 	// Check if the most recent blocks that we'll be considering in hot feed computation have been processed.
 	for _, blockNode := range fes.blockchain.BestChain() {
@@ -827,6 +827,11 @@ func GetPostHashToScoreForTxn(txn *lib.MsgDeSoTxn,
 	// If we haven't gotten the post entry yet, make sure we fetch it.
 	if interactionPostEntry == nil {
 		interactionPostEntry = utxoView.GetPostEntryForPostHash(interactionPostHash)
+	}
+
+	// Double check that we got a valid interaction post entry. If not, bail.
+	if interactionPostEntry == nil {
+		return nil, nil
 	}
 
 	// At this point, we have a post hash to return so look up the posterPKID as well.

--- a/routes/hot_feed.go
+++ b/routes/hot_feed.go
@@ -504,12 +504,7 @@ func (fes *APIServer) PopulateHotnessInfoMap(
 	postInteractionMap := make(map[HotFeedInteractionKey]uint64)
 
 	// Fake block height for mempool transactions that haven't been mined yet
-	var mempoolBlockHeight int
-	if len(hotnessInfoBlocks) > 0 {
-		mempoolBlockHeight = hotnessInfoBlocks[0].BlockAge + 1
-	} else {
-		mempoolBlockHeight = 1
-	}
+	mempoolBlockHeight := fes.blockchain.BlockTip().Height + 1
 
 	// Create new "block" for mempool txns, give it a block age of 1 greater than the current tip
 

--- a/routes/hot_feed.go
+++ b/routes/hot_feed.go
@@ -82,7 +82,7 @@ func (fes *APIServer) StartHotFeedRoutine() {
 	out:
 		for {
 			select {
-			case <-time.After(60 * time.Second):
+			case <-time.After(30 * time.Second):
 				resetCache := false
 				if cacheResetCounter >= ResetCachesIterationLimit {
 					resetCache = true

--- a/routes/hot_feed.go
+++ b/routes/hot_feed.go
@@ -446,10 +446,10 @@ func (fes *APIServer) UpdateHotFeedOrderedList(
 	// Create new "block" for mempool txns, give it a block age of 1 greater than the current tip
 
 	// First get all MempoolTxns from mempool.
-	dbMempoolTxnsOrderedByTime, _, err := fes.backendServer.GetMempool().GetTransactionsOrderedByTimeAdded()
+	mempoolTxnsOrderedByTime, _, err := fes.backendServer.GetMempool().GetTransactionsOrderedByTimeAdded()
 	// Extract MsgDesoTxn from each MempoolTxn
 	var txnsFromMempoolOrderedByTime []*lib.MsgDeSoTxn
-	for _, mempoolTxn := range dbMempoolTxnsOrderedByTime {
+	for _, mempoolTxn := range mempoolTxnsOrderedByTime {
 		txnsFromMempoolOrderedByTime = append(txnsFromMempoolOrderedByTime, mempoolTxn.Tx)
 	}
 

--- a/routes/hot_feed.go
+++ b/routes/hot_feed.go
@@ -538,7 +538,7 @@ func (fes *APIServer) PopulateHotnessInfoMap(
 	if len(hotnessInfoBlocks) > 0 {
 		glog.Infof("Here is the last hotness info block: %+v", hotnessInfoBlocks[len(hotnessInfoBlocks) - 1])
 		glog.Infof("Here is the first hotness info block: %+v", hotnessInfoBlocks[0])
-		mempoolBlockHeight = hotnessInfoBlocks[len(hotnessInfoBlocks) - 1].BlockAge + 1
+		mempoolBlockHeight = hotnessInfoBlocks[0].BlockAge + 1
 	} else {
 		mempoolBlockHeight = 1
 	}

--- a/routes/hot_feed.go
+++ b/routes/hot_feed.go
@@ -537,7 +537,8 @@ func (fes *APIServer) PopulateHotnessInfoMap(
 	glog.Infof("Here is the hotness info block len: %v", len(hotnessInfoBlocks))
 	if len(hotnessInfoBlocks) > 0 {
 		glog.Infof("Here is the last hotness info block: %+v", hotnessInfoBlocks[len(hotnessInfoBlocks) - 1])
-		mempoolBlockHeight = hotnessInfoBlocks[len(hotnessInfoBlocks) - 1].BlockAge
+		glog.Infof("Here is the first hotness info block: %+v", hotnessInfoBlocks[0])
+		mempoolBlockHeight = hotnessInfoBlocks[len(hotnessInfoBlocks) - 1].BlockAge + 1
 	} else {
 		mempoolBlockHeight = 1
 	}

--- a/routes/hot_feed.go
+++ b/routes/hot_feed.go
@@ -544,8 +544,9 @@ func (fes *APIServer) PopulateHotnessInfoMap(
 	dbMempoolTxnsOrderedByTime, err := lib.DbGetAllMempoolTxnsSortedByTimeAdded(utxoView.Handle)
 
 	if err != nil {
-		glog.Infof("Error getting mempool transactions: %v", err)
+		glog.Errorf("Error getting mempool transactions: %v", err)
 	} else if len(dbMempoolTxnsOrderedByTime) > 0 {
+		glog.Infof("Retrieved %v transactions from mempool, height %v", len(dbMempoolTxnsOrderedByTime), mempoolBlockHeight)
 		hotnessInfoBlocks = append(hotnessInfoBlocks, &HotnessInfoBlock{
 			Block:    &lib.MsgDeSoBlock{
 				Txns: dbMempoolTxnsOrderedByTime,


### PR DESCRIPTION
This pull request adds in hot feed transactions to the current hot feed scoring mechanism. 

This update also reduces the lookback period for the hotfeed and as a result increases the cadence at which the hot feed is updated. 

This PR also removes logic that limits hot feed calculation to whenever new blocks are produced, as presumably every run there will be new txns in the mempool.

This PR also allows the scoring of posts with no interactions. This allows tagged feeds to include new posts without interaction.