### PR TITLE
Fix node shutdown

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -36,7 +36,9 @@ func Run(cmd *cobra.Command, args []string) {
 		glog.Info("Shutdown complete")
 	}()
 
-	<-shutdownListener
+	if shutdownListener != nil {
+		<-shutdownListener
+	}
 }
 
 func init() {

--- a/scripts/tools/clear_ancestral_records.go
+++ b/scripts/tools/clear_ancestral_records.go
@@ -9,7 +9,7 @@ import (
 )
 
 func main() {
-	dbDir := "/Users/piotr/data_dirs/hypersync/runner"
+	dbDir := "$HOME/data_dirs/hypersync/runner"
 
 	db, err := toolslib.OpenDataDir(dbDir)
 	if err != nil {

--- a/scripts/tools/compare_database.go
+++ b/scripts/tools/compare_database.go
@@ -12,8 +12,8 @@ import (
 )
 
 func main() {
-	dir0 := "/Users/piotr/data_dirs/hypersync/mini_sentry_nft"
-	dir1 := "/Users/piotr/data_dirs/hypersync/control_sentry_nft"
+	dir0 := "$HOME/data_dirs/hypersync/mini_sentry_nft"
+	dir1 := "$HOME/data_dirs/hypersync/control_sentry_nft"
 
 	db0, err := toolslib.OpenDataDir(dir0)
 	if err != nil {

--- a/scripts/tools/compare_prefix.go
+++ b/scripts/tools/compare_prefix.go
@@ -8,8 +8,8 @@ import (
 )
 
 func main() {
-	dir0 := "/Users/piotr/data_dirs/n69_5"
-	dir1 := "/Users/piotr/data_dirs/n69_2"
+	dir0 := "$HOME/data_dirs/n69_5"
+	dir1 := "$HOME/data_dirs/n69_2"
 	//dir2 := "/Users/piotr/data_dirs/n7_1"
 
 	db0, err := toolslib.OpenDataDir(dir0)

--- a/scripts/tools/compute_db_checksum.go
+++ b/scripts/tools/compute_db_checksum.go
@@ -12,7 +12,7 @@ import (
 )
 
 func main() {
-	dirSnap := "/Users/piotr/data_dirs/hypersync/final_nodes/runner_node"
+	dirSnap := "$HOME/data_dirs/hypersync/final_nodes/runner_node"
 	time.Sleep(1 * time.Millisecond)
 	dbSnap, err := toolslib.OpenDataDir(dirSnap)
 	if err != nil {

--- a/scripts/tools/copy_node_db.go
+++ b/scripts/tools/copy_node_db.go
@@ -7,8 +7,8 @@ import (
 )
 
 func main() {
-	sourceDbDir := "/Users/piotr/data_dirs/hypersync/mini_sentry_nft"
-	destinationDbDir := "/Users/piotr/data_dirs/hypersync/mini_sentry_nft_copy"
+	sourceDbDir := "$HOME/data_dirs/hypersync/mini_sentry_nft"
+	destinationDbDir := "$HOME/data_dirs/hypersync/mini_sentry_nft_copy"
 
 	sourceDb, err := toolslib.OpenDataDir(sourceDbDir)
 	if err != nil {


### PR DESCRIPTION
If you were to start a node and then immediately stop it, the backend node would have continued to run indefinitely. This PR fixes this.