### PR TITLE
Extend follow feed to be configurable length or infinite

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -172,7 +172,7 @@ func init() {
 	})
 
 	// Follow Feed Length
-    runCmd.PersistentFlags().Bool("follow-feed-infinite", false, "Return the entire follow feed")
+	runCmd.PersistentFlags().Bool("follow-feed-infinite", false, "Return the entire follow feed")
 	runCmd.PersistentFlags().Int("follow-feed-length", 2, "Number of days of content to fetch for follow feed")
 
 	rootCmd.AddCommand(runCmd)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -171,5 +171,9 @@ func init() {
 		viper.BindPFlag(flag.Name, flag)
 	})
 
+	// Follow Feed Length
+    runCmd.PersistentFlags().Bool("follow-feed-infinite", false, "Return the entire follow feed")
+	runCmd.PersistentFlags().Int("follow-feed-length", 2, "Number of days of content to fetch for follow feed")
+
 	rootCmd.AddCommand(runCmd)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -84,6 +84,10 @@ type Config struct {
 
 	// Public keys that need their balances monitored. Map of Label to Public key
 	PublicKeyBalancesToMonitor map[string][]byte
+
+	// Follow Feed Length
+    FollowFeedInfinite bool
+	FollowFeedLength int
 }
 
 func LoadConfig(coreConfig *coreCmd.Config) *Config {
@@ -195,6 +199,10 @@ func LoadConfig(coreConfig *coreCmd.Config) *Config {
 			config.PublicKeyBalancesToMonitor[entry[0]] = pubKeyBytes
 		}
 	}
+
+	// Follow Feed Length
+	config.FollowFeedInfinite = viper.GetBool("follow-feed-infinite")
+	config.FollowFeedLength = viper.GetInt("follow-feed-length")
 
 	return &config
 }

--- a/config/config.go
+++ b/config/config.go
@@ -86,8 +86,8 @@ type Config struct {
 	PublicKeyBalancesToMonitor map[string][]byte
 
 	// Follow Feed Length
-    FollowFeedInfinite bool
-	FollowFeedLength int
+	FollowFeedInfinite bool
+	FollowFeedLength   int
 }
 
 func LoadConfig(coreConfig *coreCmd.Config) *Config {

--- a/routes/exchange.go
+++ b/routes/exchange.go
@@ -1620,7 +1620,7 @@ func (fes *APIServer) GetPostsForFollowFeedForPublicKey(bav *lib.UtxoView, start
 	minTimestampNanos := uint64(time.Now().UTC().AddDate(0, 0, -fes.Config.FollowFeedLength).UnixNano()) // default: two days ago
 
 	if fes.Config.FollowFeedInfinite {
-	    minTimestampNanos = 0 // Fetch all posts for infinite follow feed
+		minTimestampNanos = 0 // Fetch all posts for infinite follow feed
 	}
 	// For each of these pub keys, get their posts, and load them into the view too
 	for _, followedPubKey := range filteredPubKeysMap {

--- a/routes/exchange.go
+++ b/routes/exchange.go
@@ -1617,7 +1617,11 @@ func (fes *APIServer) GetPostsForFollowFeedForPublicKey(bav *lib.UtxoView, start
 		return nil, errors.Wrapf(err, "GetPostsForFollowFeedForPublicKey: Problem filtering out restricted public keys: ")
 	}
 
-	minTimestampNanos := uint64(time.Now().UTC().AddDate(0, 0, -2).UnixNano()) // two days ago
+	minTimestampNanos := uint64(time.Now().UTC().AddDate(0, 0, -fes.Config.FollowFeedLength).UnixNano()) // default: two days ago
+
+	if fes.Config.FollowFeedInfinite {
+	    minTimestampNanos = 0 // Fetch all posts for infinite follow feed
+	}
 	// For each of these pub keys, get their posts, and load them into the view too
 	for _, followedPubKey := range filteredPubKeysMap {
 


### PR DESCRIPTION
This PR adds 2 new flags, `follow-feed-length` and `follow-feed-infinite` that allow node operators to configure their follow feeds to go back any amount of days or be infinite. The current behavior is a follow feed that goes back 2 days.