### PR TITLE
Validate DAO coin order transfer restriction.

### DIFF
--- a/routes/dao_coin_exchange.go
+++ b/routes/dao_coin_exchange.go
@@ -1,6 +1,7 @@
 package routes
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"github.com/deso-protocol/core/lib"
@@ -926,6 +927,62 @@ func (fes *APIServer) validateTransactorSellingCoinBalance(
 	}
 
 	// Happy path. No error. Transactor has sufficient balance to cover their selling quantity.
+	return nil
+}
+
+func (fes *APIServer) validateDAOCoinOrderTransferRestriction(
+	transactorPublicKeyBase58Check string, buyingDAOCoinCreatorPublicKeyBase58Check string) error {
+
+	// If buying $DESO, this never has a transfer restriction. We validate
+	// that you own sufficient of your selling coin elsewhere.
+	if buyingDAOCoinCreatorPublicKeyBase58Check == DESOCoinIdentifierString {
+		return nil
+	}
+
+	// Get UTXO view.
+	utxoView, err := fes.backendServer.GetMempool().GetAugmentedUniversalView()
+	if err != nil {
+		return errors.Errorf("Problem fetching UTXOView: %v", err)
+	}
+
+	// Get transactor PublicKey from PublicKeyBase58Check.
+	transactorPublicKey, _, err := lib.Base58CheckDecode(transactorPublicKeyBase58Check)
+	if err != nil {
+		return errors.Errorf("Error decoding transactor public key: %v", err)
+	}
+
+	// Get buying DAO coin creator PublicKey from PublicKeyBase58Check.
+	buyingCoinPublicKey, _, err := lib.Base58CheckDecode(buyingDAOCoinCreatorPublicKeyBase58Check)
+	if err != nil {
+		return errors.Errorf("Error decoding buying DAO coin creator public key: %v", err)
+	}
+
+	// Get buying DAO coin profile entry.
+	profileEntry := utxoView.GetProfileEntryForPublicKey(buyingCoinPublicKey)
+	if profileEntry == nil || profileEntry.IsDeleted() {
+		return errors.New("Buying DAO coin creator profile entry not found")
+	}
+
+	// Validate if transfer restriction status is PROFILE OWNER ONLY.
+	if profileEntry.DAOCoinEntry.TransferRestrictionStatus == lib.TransferRestrictionStatusProfileOwnerOnly &&
+		!bytes.Equal(transactorPublicKey, buyingCoinPublicKey) {
+		return errors.New("Buying this DAO coin is restricted to the creator of the DAO")
+	}
+
+	// Validate if transfer restriction status is MEMBERS ONLY.
+	if profileEntry.DAOCoinEntry.TransferRestrictionStatus == lib.TransferRestrictionStatusDAOMembersOnly {
+		// Retrieve transactor's DAO coin balance.
+		balanceEntry, _, _ := utxoView.GetBalanceEntryForHODLerPubKeyAndCreatorPubKey(transactorPublicKey, buyingCoinPublicKey, true)
+		if balanceEntry == nil {
+			return errors.New("Transactor DAO coin balance entry not found")
+		}
+
+		// Error if balance is zero.
+		if balanceEntry.BalanceNanos.IsZero() {
+			return errors.New("Buying this DAO coin is restricted to users who already own this DAO coin")
+		}
+	}
+
 	return nil
 }
 

--- a/routes/dao_coin_exchange.go
+++ b/routes/dao_coin_exchange.go
@@ -971,14 +971,9 @@ func (fes *APIServer) validateDAOCoinOrderTransferRestriction(
 
 	// Validate if transfer restriction status is MEMBERS ONLY.
 	if profileEntry.DAOCoinEntry.TransferRestrictionStatus == lib.TransferRestrictionStatusDAOMembersOnly {
-		// Retrieve transactor's DAO coin balance.
+		// Retrieve transactor's DAO coin balance. Error if balance is zero.
 		balanceEntry, _, _ := utxoView.GetBalanceEntryForHODLerPubKeyAndCreatorPubKey(transactorPublicKey, buyingCoinPublicKey, true)
-		if balanceEntry == nil {
-			return errors.New("Transactor DAO coin balance entry not found")
-		}
-
-		// Error if balance is zero.
-		if balanceEntry.BalanceNanos.IsZero() {
+		if balanceEntry == nil || balanceEntry.BalanceNanos.IsZero() {
 			return errors.New("Buying this DAO coin is restricted to users who already own this DAO coin")
 		}
 	}

--- a/routes/transaction.go
+++ b/routes/transaction.go
@@ -2700,6 +2700,15 @@ func (fes *APIServer) CreateDAOCoinLimitOrder(ww http.ResponseWriter, req *http.
 		return
 	}
 
+	// Validate any transfer restrictions on buying the DAO coin.
+	err = fes.validateDAOCoinOrderTransferRestriction(
+		requestData.TransactorPublicKeyBase58Check,
+		requestData.BuyingDAOCoinCreatorPublicKeyBase58Check)
+	if err != nil {
+		_AddBadRequestError(ww, fmt.Sprintf("CreateDAOCoinLimitOrder: %v", err))
+		return
+	}
+
 	// Create order.
 	res, err := fes.createDAOCoinLimitOrderResponse(
 		utxoView,
@@ -2827,6 +2836,15 @@ func (fes *APIServer) CreateDAOCoinMarketOrder(ww http.ResponseWriter, req *http
 			ww,
 			fmt.Sprintf("CreateDAOCoinMarketOrder: %v fill type not supported for market orders", requestData.FillType),
 		)
+		return
+	}
+
+	// Validate any transfer restrictions on buying the DAO coin.
+	err = fes.validateDAOCoinOrderTransferRestriction(
+		requestData.TransactorPublicKeyBase58Check,
+		requestData.BuyingDAOCoinCreatorPublicKeyBase58Check)
+	if err != nil {
+		_AddBadRequestError(ww, fmt.Sprintf("CreateDAOCoinMarketOrder: %v", err))
 		return
 	}
 


### PR DESCRIPTION
This is already validated in core, but this check will provide more immediate feedback to the user if there is a relevant error message.