### PR TITLE
"get-posts-for-public-key" endpoint: Added "IncludeComments" flag to …

### DIFF
--- a/routes/admin_referrals.go
+++ b/routes/admin_referrals.go
@@ -952,7 +952,7 @@ func (fes *APIServer) AdminDownloadRefereeCSV(ww http.ResponseWriter, req *http.
 		// it is not critical.
 		refereePostsLen := int64(-1)
 		refereePostEntries, err := utxoView.GetPostsPaginatedForPublicKeyOrderedByTimestamp(
-			refereePKID[:], nil, 1000, false, false)
+			refereePKID[:], nil, 1000, false, false, false)
 		if err == nil {
 			refereePostsLen = int64(len(refereePostEntries))
 		}

--- a/routes/nft.go
+++ b/routes/nft.go
@@ -2044,7 +2044,7 @@ func (fes *APIServer) GetNFTsCreatedByPublicKey(ww http.ResponseWriter, req *htt
 	}
 
 	// Get Posts Ordered by time.
-	posts, err := utxoView.GetPostsPaginatedForPublicKeyOrderedByTimestamp(publicKeyBytes, startPostHash, requestData.NumToFetch, false, true)
+	posts, err := utxoView.GetPostsPaginatedForPublicKeyOrderedByTimestamp(publicKeyBytes, startPostHash, requestData.NumToFetch, false, true, false)
 	if err != nil {
 		_AddBadRequestError(ww, fmt.Sprintf("GetNFTsCreatedByPublicKey: Problem getting paginated NFTs: %v", err))
 		return

--- a/routes/post.go
+++ b/routes/post.go
@@ -1437,6 +1437,8 @@ type GetPostsForPublicKeyRequest struct {
 	// Number of records to fetch
 	NumToFetch    uint64 `safeForLogging:"true"`
 	MediaRequired bool   `safeForLogging:"true"`
+	// Include comment posts (those having a parent), or not
+	IncludeComments bool `safeForLogging:"true"`
 }
 
 // GetPostsForPublicKeyResponse ...
@@ -1501,7 +1503,7 @@ func (fes *APIServer) GetPostsForPublicKey(ww http.ResponseWriter, req *http.Req
 	}
 
 	// Get Posts Ordered by time.
-	posts, err := utxoView.GetPostsPaginatedForPublicKeyOrderedByTimestamp(publicKeyBytes, startPostHash, requestData.NumToFetch, requestData.MediaRequired, false)
+	posts, err := utxoView.GetPostsPaginatedForPublicKeyOrderedByTimestamp(publicKeyBytes, startPostHash, requestData.NumToFetch, requestData.MediaRequired, false, requestData.IncludeComments)
 	if err != nil {
 		_AddBadRequestError(ww, fmt.Sprintf("GetPostsForPublicKey: Problem getting paginated posts: %v", err))
 		return


### PR DESCRIPTION
…allow to also fetch comment posts.

See: https://github.com/deso-protocol/dips/discussions/93#discussioncomment-4120746

⚠ Depends on twin PR (https://github.com/deso-protocol/core/pull/417) in core.