### PR TITLE
Feature get posts hashlist

### DIFF
--- a/routes/post.go
+++ b/routes/post.go
@@ -998,6 +998,7 @@ func (fes *APIServer) GetPostsHashlist(ww http.ResponseWriter, req *http.Request
 	}
 
 	postEntryResponses := []*PostEntryResponse{}
+	var profileEntryMap map[lib.PkMapKey]*lib.ProfileEntry
 	for _, postHashHex := range requestData.PostsHashlist {
 		postHash, err := GetPostHashFromPostHashHex(postHashHex)
 		if err != nil {

--- a/routes/post.go
+++ b/routes/post.go
@@ -984,6 +984,11 @@ func (fes *APIServer) GetPostsHashHexList(ww http.ResponseWriter, req *http.Requ
 		return
 	}
 
+	if len(requestData.PostsHashHexList) == 0 {
+		_AddBadRequestError(ww, fmt.Sprint("GetPostsHashHexList: PostsHashHexList is empty"))
+		return
+	}
+
 	if len(requestData.PostsHashHexList) > 50 {
 		_AddBadRequestError(ww, fmt.Sprint("GetPostsHashHexList: The number of posthash is limited to 50"))
 		return

--- a/routes/post.go
+++ b/routes/post.go
@@ -1017,6 +1017,9 @@ func (fes *APIServer) GetPostsHashlist(ww http.ResponseWriter, req *http.Request
 			// Just ignore posts that fail to convert for whatever reason.
 			continue
 		}
+		profileEntryFound := profileEntryMap[lib.MakePkMapKey(postEntry.PosterPublicKey)]
+		postEntryResponse.ProfileEntryResponse = fes._profileEntryToResponse(
+			profileEntryFound, utxoView)
 
 		//postEntryResponse.PostEntryReaderState = readerStateMap[*postEntry.PostHash]
 		postEntryResponses = append(postEntryResponses, postEntryResponse)

--- a/routes/server.go
+++ b/routes/server.go
@@ -99,6 +99,7 @@ const (
 	RoutePathGetTransactorDaoCoinLimitOrders = "/api/v0/get-transactor-dao-coin-limit-orders"
 
 	// post.go
+	RoutePathGetPostsHashlist       = "/api/v0/get-posts-hashlist"
 	RoutePathGetPostsStateless      = "/api/v0/get-posts-stateless"
 	RoutePathGetSinglePost          = "/api/v0/get-single-post"
 	RoutePathGetLikesForPost        = "/api/v0/get-likes-for-post"
@@ -646,6 +647,14 @@ func (fes *APIServer) NewRouter() *muxtrace.Router {
 			[]string{"POST", "OPTIONS"},
 			RoutePathSubmitPost,
 			fes.SubmitPost,
+			PublicAccess,
+		},
+		{
+			"GetPostsHashlist",
+			[]string{"POST", "OPTIONS"},
+			RoutePathGetPostsHashlist,
+			fes.GetPostsHashlist,
+			// CheckSecret: No need to check the secret since this is a read-only endpoint.
 			PublicAccess,
 		},
 		{

--- a/routes/server.go
+++ b/routes/server.go
@@ -100,7 +100,7 @@ const (
 	RoutePathGetTransactorDaoCoinLimitOrders = "/api/v0/get-transactor-dao-coin-limit-orders"
 
 	// post.go
-	RoutePathGetPostsHashlist       = "/api/v0/get-posts-hashlist"
+	RoutePathGetPostsHashHexList    = "/api/v0/get-posts-hashhexlist"
 	RoutePathGetPostsStateless      = "/api/v0/get-posts-stateless"
 	RoutePathGetSinglePost          = "/api/v0/get-single-post"
 	RoutePathGetLikesForPost        = "/api/v0/get-likes-for-post"
@@ -655,11 +655,10 @@ func (fes *APIServer) NewRouter() *muxtrace.Router {
 			PublicAccess,
 		},
 		{
-			"GetPostsHashlist",
+			"PostsHashHexList",
 			[]string{"POST", "OPTIONS"},
-			RoutePathGetPostsHashlist,
-			fes.GetPostsHashlist,
-			// CheckSecret: No need to check the secret since this is a read-only endpoint.
+			RoutePathGetPostsHashHexList,
+			fes.GetPostsHashHexList,
 			PublicAccess,
 		},
 		{


### PR DESCRIPTION
Added an endpoint get-posts-hashlist which can retrieve posts from an array of PostHashes.

Sample payload:

```
{
    "PostsHashList": ["bdebcb4b5ebf10bd20f8db3e8be55d5b618c7302ea7415967079c4ed58a746e6", "62ef62991f56d05f6cf55f06080d64e438a6529d58fae57822f1ab9cf34600f1","ba448a92b26a3aa4a2fb5e3f8d03e1956f87f26192503c6dd13031c34d9ea54a", "3a4d6f5b50512f36ed868c406e522775bba9637502cb9708ff3fbb451c70baf5" ],
    "ReaderPublicKeyBase58Check": "BC1YLhDaBCuTnctb44A9yV4hiQu2GV3g3672nHyDYxQoSQ3E7Jk2QHY",
    "OrderBy": ""
}
```

I have multiple projects waiting for this:
- DeSocialWorld
- Gemstori
- Videso

