### PR TITLE
Blacklist and graylist by username

### DIFF
--- a/routes/admin_user.go
+++ b/routes/admin_user.go
@@ -231,7 +231,7 @@ type AdminUpdateUsernameBlacklistRequest struct {
 // AdminUpdateUsernameBlacklist...
 //
 // This endpoint allows an admin to blacklist or graylist an account by username.
-// This is important as it prevents malicous users using a deceiptful username from continuing to username change
+// This is important as it prevents malicious users using a deceitful username from continuing to username change
 // once their public key is blocked, as the username itself is the entity being blacklisted/graylisted.
 func (fes *APIServer) AdminUpdateUsernameBlacklist(ww http.ResponseWriter, req *http.Request) {
 	decoder := json.NewDecoder(io.LimitReader(req.Body, MaxRequestBodySizeBytes))

--- a/routes/admin_user.go
+++ b/routes/admin_user.go
@@ -214,6 +214,87 @@ func (fes *APIServer) AdminUpdateUserGlobalMetadata(ww http.ResponseWriter, req 
 	// Simply return with a 200 status code
 }
 
+// AdminUpdateUsernameBlacklistRequest...
+type AdminUpdateUsernameBlacklistRequest struct {
+	// The username associated with the blacklist/graylist update.
+	Username string `safeForLogging:"true"`
+
+	// Whether we are updating the blacklist (true) or the graylist (false).
+	IsBlacklistUpdate bool
+
+	// Set to true if this user's content should not show up anywhere on the site.
+	AddUserToList bool `safeForLogging:"true"`
+
+	AdminPublicKey string
+}
+
+// AdminUpdateUsernameBlacklist...
+//
+// This endpoint allows an admin to blacklist or graylist an account by username.
+// This is important as it prevents malicous users using a deceiptful username from continuing to username change
+// once their public key is blocked, as the username itself is the entity being blacklisted/graylisted.
+func (fes *APIServer) AdminUpdateUsernameBlacklist(ww http.ResponseWriter, req *http.Request) {
+	decoder := json.NewDecoder(io.LimitReader(req.Body, MaxRequestBodySizeBytes))
+	requestData := AdminUpdateUsernameBlacklistRequest{}
+	if err := decoder.Decode(&requestData); err != nil {
+		_AddBadRequestError(ww, fmt.Sprintf("AdminUpdateUsernameBlacklist: Problem parsing request body: %v", err))
+		return
+	}
+
+	if requestData.Username == "" {
+		_AddBadRequestError(ww,
+			fmt.Sprintf("AdminUpdateUsernameBlacklist: Must provide a valid username."))
+		return
+	}
+
+	username := strings.ToLower(requestData.Username)
+
+	// If we are adding a user to the blacklist or removing the user from all lists, update their value in the global state.
+	if requestData.IsBlacklistUpdate || !requestData.AddUserToList {
+		blacklistKey := GlobalStateKeyForBlacklistedProfileByUsername(username)
+		blacklistVal := lib.NotBlacklisted
+		blacklistAction := "removing from"
+		if requestData.AddUserToList {
+			blacklistVal = lib.IsBlacklisted
+			blacklistAction = "adding to"
+		}
+
+		if requestData.AddUserToList && reflect.DeepEqual(fes.GetBlacklistStateForUsername(username), IsBlacklisted) {
+			_AddBadRequestError(ww, fmt.Sprintf("AdminUpdateUsernameBlacklist: username %v is already blacklisted", username))
+			return
+		}
+
+		if err := fes.GlobalState.Put(blacklistKey, blacklistVal); err != nil {
+			_AddBadRequestError(ww, fmt.Sprintf("AdminUpdateUsernameBlacklist: Problem %v blacklist: %v", blacklistAction, err))
+			return
+		}
+	}
+
+	// If we are adding a user to the graylist or removing the user from all lists, update their value in the global state.
+	if !requestData.IsBlacklistUpdate || !requestData.AddUserToList {
+		// We need to update global state's list of graylisted users.
+		graylistkey := GlobalStateKeyForGraylistedProfileByUsername(username)
+		graylistVal := lib.NotGraylisted
+		graylistAction := "removing from"
+		if requestData.AddUserToList {
+			graylistVal = lib.IsGraylisted
+			graylistAction = "adding to"
+		}
+		if reflect.DeepEqual(fes.GetGraylistStateForUsername(username), IsGraylisted) {
+			_AddBadRequestError(ww, fmt.Sprintf("AdminUpdateUsernameBlacklist: username %v is already graylisted", username))
+			return
+		}
+		if err := fes.GlobalState.Put(graylistkey, graylistVal); err != nil {
+			_AddBadRequestError(ww, fmt.Sprintf("AdminUpdateUsernameBlacklist: Problem %v graylist: %v", graylistAction, err))
+			return
+		}
+	}
+	// Force Blacklist and Graylist to update instantly.
+	fes.SetBlacklistedUsernameMap()
+	fes.SetGraylistedUsernameMap()
+
+}
+
 type AdminResetPhoneNumberRequest struct {
 	PhoneNumber string
 }

--- a/routes/global_state.go
+++ b/routes/global_state.go
@@ -232,7 +232,15 @@ var (
 	// same ID.
 	//
 
-	// NEXT_TAG: 46
+	// The prefix for accessing the graylisted users by username.
+	// <prefix, username> -> <IsGraylisted>
+	_GlobalStatePrefixUsernameToGraylistState = []byte{46}
+
+	// The prefix for accesing the blacklisted users by username.
+	// <prefix, username> -> <IsBlacklisted>
+	_GlobalStatePrefixUsernameToBlacklistState = []byte{47}
+
+	// NEXT_TAG: 48
 
 )
 
@@ -630,10 +638,17 @@ func GlobalStateKeyForWhitelistAuditLogs(username string) []byte {
 	return key
 }
 
-// Key for accessing a graylisted user.
+// Key for accessing a graylisted user by public key.
 func GlobalStateKeyForGraylistedProfile(profilePubKey []byte) []byte {
 	key := append([]byte{}, _GlobalStatePrefixPublicKeyToGraylistState...)
 	key = append(key, profilePubKey...)
+	return key
+}
+
+// Key for accessing a graylisted user by username.
+func GlobalStateKeyForGraylistedProfileByUsername(username string) []byte {
+	key := append([]byte{}, _GlobalStatePrefixUsernameToGraylistState...)
+	key = append(key, []byte(strings.ToLower(username))...)
 	return key
 }
 
@@ -644,10 +659,17 @@ func GlobalStateKeyForGraylistAuditLogs(username string) []byte {
 	return key
 }
 
-// Key for accessing a blacklisted user.
+// Key for accessing a blacklisted user by public key.
 func GlobalStateKeyForBlacklistedProfile(profilePubKey []byte) []byte {
 	key := append([]byte{}, _GlobalStatePrefixPublicKeyToBlacklistState...)
 	key = append(key, profilePubKey...)
+	return key
+}
+
+// Key for accessing a blacklisted user by username.
+func GlobalStateKeyForBlacklistedProfileByUsername(username string) []byte {
+	key := append([]byte{}, _GlobalStatePrefixUsernameToBlacklistState...)
+	key = append(key, []byte(strings.ToLower(username))...)
 	return key
 }
 

--- a/routes/post.go
+++ b/routes/post.go
@@ -1337,7 +1337,7 @@ func (fes *APIServer) GetSinglePost(ww http.ResponseWriter, req *http.Request) {
 	if _, ok := filteredProfilePubKeyMap[lib.MakePkMapKey(postEntry.PosterPublicKey)]; !ok {
 		currentPosterPKID := utxoView.GetPKIDForPublicKey(postEntry.PosterPublicKey)
 		// If the currentPoster's userMetadata doesn't exist, then they are no greylisted, so we can exit.
-		if fes.IsUserGraylisted(currentPosterPKID.PKID) && !fes.IsUserBlacklisted(currentPosterPKID.PKID) {
+		if fes.IsUserGraylisted(currentPosterPKID.PKID, utxoView) && !fes.IsUserBlacklisted(currentPosterPKID.PKID, utxoView) {
 			// If the currentPoster is not blacklisted (removed everywhere) and is greylisted (removed from leaderboard)
 			// add them back to the filteredProfilePubKeyMap and note that the currentPoster is greylisted.
 			isCurrentPosterGreylisted = true

--- a/routes/server.go
+++ b/routes/server.go
@@ -209,6 +209,7 @@ const (
 	RoutePathAdminGetUsernameVerificationAuditLogs = "/api/v0/admin/get-username-verification-audit-logs"
 	RoutePathAdminGetUserAdminData                 = "/api/v0/admin/get-user-admin-data"
 	RoutePathAdminResetPhoneNumber                 = "/api/v0/admin/reset-phone-number"
+	RoutePathAdminUpdateUsernameBlacklist          = "/api/v0/admin/update-username-blacklist"
 
 	// admin_feed.go
 	RoutePathAdminUpdateGlobalFeed = "/api/v0/admin/update-global-feed"
@@ -264,6 +265,8 @@ const (
 	RoutePathGetVerifiedUsernames     = "/api/v0/get-verified-usernames"
 	RoutePathGetBlacklistedPublicKeys = "/api/v0/get-blacklisted-public-keys"
 	RoutePathGetGraylistedPublicKeys  = "/api/v0/get-graylisted-public-keys"
+	RoutePathGetBlacklistedUsernames  = "/api/v0/get-blacklisted-usernames"
+	RoutePathGetGraylistedUsernames   = "/api/v0/get-graylisted-usernames"
 	RoutePathGetGlobalFeed            = "/api/v0/get-global-feed"
 
 	// supply.go
@@ -375,6 +378,9 @@ type APIServer struct {
 	// BlacklistedPKIDMap is a map of PKID to a byte slice representing the PKID of a user as the key and the current
 	// blacklist state of that user as the key. If a PKID is not present in this map, then the user is NOT blacklisted.
 	BlacklistedPKIDMap map[lib.PKID][]byte
+	// BlacklistedUsernameMap is a map of username to a byte slice representing the username of a user as the key and the current
+	// blacklist state of that user as the key. If a username is not present in this map, then the username is NOT blacklisted.
+	BlacklistedUsernameMap map[string][]byte
 	// BlacklistedResponseMap is a map of PKIDs converted to base58-encoded string to a byte slice. This is computed
 	// from the BlacklistedPKIDMap above and is a JSON-encodable version of that map. This map is only used when
 	// responding to requests for this node's blacklist. A JSON-encoded response is easier for any language to digest
@@ -383,6 +389,9 @@ type APIServer struct {
 	// GraylistedPKIDMap is a map of PKID to a byte slice representing the PKID of a user as the key and the current
 	// graylist state of that user as the key. If a PKID is not present in this map, then the user is NOT graylisted.
 	GraylistedPKIDMap map[lib.PKID][]byte
+	// GraylistedUsernameMap is a map of username to a byte slice representing the username of a user as the key and the current
+	// graylist state of that user as the key. If a username is not present in this map, then the username is NOT graylisted.
+	GraylistedUsernameMap map[string][]byte
 	// GraylistedResponseMap is a map of PKIDs converted to base58-encoded string to a byte slice. This is computed
 	// from the GraylistedPKIDMap above and is a JSON-encodable version of that map. This map is only used when
 	// responding to requests for this node's graylist. A JSON-encoded response is easier for any language to digest
@@ -1238,6 +1247,13 @@ func (fes *APIServer) NewRouter() *muxtrace.Router {
 			AdminAccess,
 		},
 		{
+			"AdminUpdateUsernameBlacklist",
+			[]string{"POST", "OPTIONS"},
+			RoutePathAdminUpdateUsernameBlacklist,
+			fes.AdminUpdateUsernameBlacklist,
+			AdminAccess,
+		},
+		{
 			"AdminGetVerifiedUsers",
 			[]string{"POST", "OPTIONS"},
 			RoutePathAdminGetVerifiedUsers,
@@ -1766,6 +1782,20 @@ func (fes *APIServer) NewRouter() *muxtrace.Router {
 			[]string{"GET"},
 			RoutePathGetGraylistedPublicKeys,
 			fes.GetGraylistedPublicKeys,
+			PublicAccess,
+		},
+		{
+			"GetBlacklistedUsernames",
+			[]string{"GET"},
+			RoutePathGetBlacklistedUsernames,
+			fes.GetBlacklistedUsernames,
+			PublicAccess,
+		},
+		{
+			"GetGraylistedUsernames",
+			[]string{"GET"},
+			RoutePathGetGraylistedUsernames,
+			fes.GetGraylistedUsernames,
 			PublicAccess,
 		},
 		{
@@ -2321,6 +2351,8 @@ func (fes *APIServer) SetGlobalStateCache() {
 	fes.SetVerifiedUsernameMap()
 	fes.SetBlacklistedPKIDMap(utxoView)
 	fes.SetGraylistedPKIDMap(utxoView)
+	fes.SetBlacklistedUsernameMap()
+	fes.SetGraylistedUsernameMap()
 	fes.SetGlobalFeedPostHashes(utxoView)
 	fes.SetAllCountrySignUpBonusMetadata()
 	fes.SetUSDCentsToDeSoReserveExchangeRateFromGlobalState()
@@ -2361,6 +2393,24 @@ func (fes *APIServer) SetGraylistedPKIDMap(utxoView *lib.UtxoView) {
 		// node's global state. Sending a JSON-encoded version is preferable over a gob-encoded one so that any
 		// language can easily decode the response.
 		fes.GraylistedResponseMap = fes.makePKIDMapJSONEncodable(graylistMap)
+	}
+}
+
+func (fes *APIServer) SetBlacklistedUsernameMap() {
+	blacklistMap, err := fes.GetUsernameBlacklist()
+	if err != nil {
+		glog.Errorf("SetBlacklistedUsernameMap: Error getting blacklist: %v", err)
+	} else {
+		fes.BlacklistedUsernameMap = blacklistMap
+	}
+}
+
+func (fes *APIServer) SetGraylistedUsernameMap() {
+	graylistMap, err := fes.GetUsernameGraylist()
+	if err != nil {
+		glog.Errorf("SetGraylistedUsernameMap: Error getting blacklist: %v", err)
+	} else {
+		fes.GraylistedUsernameMap = graylistMap
 	}
 }
 

--- a/routes/user.go
+++ b/routes/user.go
@@ -255,9 +255,9 @@ func (fes *APIServer) updateUserFieldsStateless(user *User, utxoView *lib.UtxoVi
 	}
 
 	// Check if the user is blacklisted/graylisted
-	user.IsBlacklisted = fes.IsUserBlacklisted(pkid.PKID)
+	user.IsBlacklisted = fes.IsUserBlacklisted(pkid.PKID, utxoView)
 
-	user.IsGraylisted = fes.IsUserGraylisted(pkid.PKID)
+	user.IsGraylisted = fes.IsUserGraylisted(pkid.PKID, utxoView)
 
 	// Only set User.IsAdmin in GetUsersStateless
 	// We don't want or need to set this on every endpoint that generates a ProfileEntryResponse
@@ -1252,8 +1252,8 @@ func (fes *APIServer) GetSingleProfile(ww http.ResponseWriter, req *http.Request
 
 	// Check if the user is blacklisted/graylisted
 	pkid := utxoView.GetPKIDForPublicKey(publicKeyBytes)
-	res.IsBlacklisted = fes.IsUserBlacklisted(pkid.PKID)
-	res.IsGraylisted = fes.IsUserGraylisted(pkid.PKID)
+	res.IsBlacklisted = fes.IsUserBlacklisted(pkid.PKID, utxoView)
+	res.IsGraylisted = fes.IsUserGraylisted(pkid.PKID, utxoView)
 
 	var userMetadata *UserMetadata
 	userMetadata, err = fes.getUserMetadataFromGlobalState(publicKeyBase58Check)
@@ -2452,7 +2452,7 @@ func (fes *APIServer) _getDBNotifications(request *GetNotificationsRequest, bloc
 			}
 			// Skip transactions from blacklisted public keys
 			transactorPKID := utxoView.GetPKIDForPublicKey(transactorPkBytes)
-			if transactorPKID == nil || fes.IsUserBlacklisted(transactorPKID.PKID) {
+			if transactorPKID == nil || fes.IsUserBlacklisted(transactorPKID.PKID, utxoView) {
 				continue
 			}
 			currentIndexBytes := keysFound[ii][len(lib.DbTxindexPublicKeyPrefix(pkBytes)):]
@@ -2568,7 +2568,7 @@ func (fes *APIServer) _getMempoolNotifications(request *GetNotificationsRequest,
 				}
 				// Skip blacklisted public keys
 				transactorPKID := utxoView.GetPKIDForPublicKey(transactorPkBytes)
-				if transactorPKID == nil || fes.IsUserBlacklisted(transactorPKID.PKID) {
+				if transactorPKID == nil || fes.IsUserBlacklisted(transactorPKID.PKID, utxoView) {
 					continue
 				}
 
@@ -3540,23 +3540,65 @@ func (fes *APIServer) DeletePII(ww http.ResponseWriter, rr *http.Request) {
 }
 
 // IsUserGraylisted returns true if the user is graylisted based on the current Graylist state.
-func (fes *APIServer) IsUserGraylisted(pkid *lib.PKID) bool {
-	return reflect.DeepEqual(fes.GetGraylistState(pkid), IsGraylisted)
+func (fes *APIServer) IsUserGraylisted(pkid *lib.PKID, utxoView *lib.UtxoView) bool {
+	pkidGraylisted := reflect.DeepEqual(fes.GetGraylistStateForPkid(pkid), IsGraylisted)
+
+	usernameGraylistState := fes.GetUsernameGraylistStateForPkid(pkid, utxoView)
+	usernameGraylisted := reflect.DeepEqual(usernameGraylistState, IsGraylisted)
+
+	return pkidGraylisted || usernameGraylisted
 }
 
-// GetGraylistState returns the graylist state bytes based on the current Graylist state.
-func (fes *APIServer) GetGraylistState(pkid *lib.PKID) []byte {
+// GetGraylistStateForPkid returns the graylist state bytes based on the current Graylist state.
+func (fes *APIServer) GetGraylistStateForPkid(pkid *lib.PKID) []byte {
 	return fes.GraylistedPKIDMap[*pkid]
 }
 
-// IsUserBlacklisted returns true if the user is blacklisted based on the current Blacklist state.
-func (fes *APIServer) IsUserBlacklisted(pkid *lib.PKID) bool {
-	return reflect.DeepEqual(fes.GetBlacklistState(pkid), IsBlacklisted)
+// GetGraylistStateForUsername returns the graylist state bytes based on the current Graylist state for a username.
+func (fes *APIServer) GetGraylistStateForUsername(username string) []byte {
+	return fes.GraylistedUsernameMap[username]
 }
 
-// GetBlacklistState returns the blacklist state bytes based on the current Blacklist state.
-func (fes *APIServer) GetBlacklistState(pkid *lib.PKID) []byte {
+func (fes *APIServer) GetUsernameGraylistStateForPkid(pkid *lib.PKID, utxoView *lib.UtxoView) []byte {
+	// Get profile entry for user, in order to check if the username is graylisted or blacklisted.
+	profileEntry := utxoView.GetProfileEntryForPKID(pkid)
+	usernameGraylistState := []byte{0}
+	if profileEntry != nil && strings.ToLower(string(profileEntry.Username)) != "" {
+		lowercaseUsernameString := strings.ToLower(string(profileEntry.Username))
+		usernameGraylistState = fes.GetGraylistStateForUsername(lowercaseUsernameString)
+	}
+	return usernameGraylistState
+}
+
+// IsUserBlacklisted returns true if the user is blacklisted based on the current Blacklist state.
+func (fes *APIServer) IsUserBlacklisted(pkid *lib.PKID, utxoView *lib.UtxoView) bool {
+	pkidBlacklisted := reflect.DeepEqual(fes.GetBlacklistStateForPkid(pkid), IsBlacklisted)
+
+	usernameBlacklistState := fes.GetUsernameBlacklistStateForPkid(pkid, utxoView)
+	usernameBlacklisted := reflect.DeepEqual(usernameBlacklistState, IsBlacklisted)
+
+	return pkidBlacklisted || usernameBlacklisted
+}
+
+// GetBlacklistStateForPkid returns the blacklist state bytes based on the current Blacklist state.
+func (fes *APIServer) GetBlacklistStateForPkid(pkid *lib.PKID) []byte {
 	return fes.BlacklistedPKIDMap[*pkid]
+}
+
+// GetBlacklistStateForUsername returns the blacklist state bytes based on the current Blacklist state for a username.
+func (fes *APIServer) GetBlacklistStateForUsername(username string) []byte {
+	return fes.BlacklistedUsernameMap[username]
+}
+
+func (fes *APIServer) GetUsernameBlacklistStateForPkid(pkid *lib.PKID, utxoView *lib.UtxoView) []byte {
+	// Get profile entry for user, in order to check if the username is graylisted or blacklisted.
+	profileEntry := utxoView.GetProfileEntryForPKID(pkid)
+	usernameBlacklistState := []byte{0}
+	if profileEntry != nil && strings.ToLower(string(profileEntry.Username)) != "" {
+		lowercaseUsernameString := strings.ToLower(string(profileEntry.Username))
+		usernameBlacklistState = fes.GetBlacklistStateForUsername(lowercaseUsernameString)
+	}
+	return usernameBlacklistState
 }
 
 func (fes *APIServer) GetPubKeyAndProfileEntryForUsernameOrPublicKeyBase58Check(


### PR DESCRIPTION
Currently, nodes are only able to blacklist by profile. This means that if an account is using a deceptive username that should be blocked, once blacklisted it can simply switch the name to a new profile and continue on. This change creates a list of blocked usernames that will always be blocked, rather than tracking the profiles themselves.