### PR TITLE
Fix minor issues to speed up block processing logic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,14 +30,31 @@ COPY core/cmd       ../core/cmd
 COPY core/lib       ../core/lib
 COPY core/migrate   ../core/migrate
 
+# Install Delve debugger, specifying the installation path explicitly
+ENV GOPATH=/root/go
+RUN go install github.com/go-delve/delve/cmd/dlv@latest
+
 # build backend
-RUN GOOS=linux go build -mod=mod -a -installsuffix cgo -o bin/backend main.go
+#RUN GOOS=linux go build -mod=mod -a -installsuffix cgo -o bin/backend main.go
+# NOTE: We're running an unoptimized build here because it makes it possible to attach
+# a debugger directly to any of our running nodes. We take this trade-off for now.
+RUN GOOS=linux go build -gcflags="all=-N -l" -mod=mod -a -installsuffix cgo -o bin/backend main.go
+
 
 # create tiny image
 FROM alpine:latest
 
 RUN apk add --update vips-dev
 
+# Copy the compiled binary and the Delve binary from the build stage
 COPY --from=backend /deso/src/backend/bin/backend /deso/bin/backend
+# Updated path according to the installation path
+COPY --from=backend /root/go/bin/dlv /bin/
 
-ENTRYPOINT ["/deso/bin/backend"]
+# Expose the port Delve will listen on
+EXPOSE 2345
+
+# NOTE: The ENTRYPOINT is overwritten when a node is deployed to Kubernetes so this
+# mainly serves as an example.
+#ENTRYPOINT ["/deso/bin/backend", "run"]
+ENTRYPOINT ["/bin/dlv", "--listen=:2345", "--headless=true", "--api-version=2", "--accept-multiclient", "exec", "/deso/bin/backend"]


### PR DESCRIPTION
* The Dockerfile change in this PR switches us to compiling with debug
  settings. This slows things down a bit but it's worth it because it
means we can attach debugging instances directly to a running node
remotely.

* Otherwise, this is just extra logging.