### PR TITLE
Make dlv --continue rather than waiting for a debugger in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,4 +57,4 @@ EXPOSE 2345
 # NOTE: The ENTRYPOINT is overwritten when a node is deployed to Kubernetes so this
 # mainly serves as an example.
 #ENTRYPOINT ["/deso/bin/backend", "run"]
-ENTRYPOINT ["/bin/dlv", "--listen=:2345", "--headless=true", "--api-version=2", "--accept-multiclient", "exec", "/deso/bin/backend"]
+ENTRYPOINT ["/bin/dlv", "--listen=:2345", "--headless=true", "--api-version=2", "--accept-multiclient", "exec", "/deso/bin/backend", "--continue"]


### PR DESCRIPTION
I'm updating our run repo and the Entrypoint in our Dockerfile for backend currently waits until you connect a deubgger to it to keep going. This fixes it.