### PR TITLE
Add simple status check for node to backend

### DIFF
--- a/routes/server.go
+++ b/routes/server.go
@@ -317,7 +317,8 @@ const (
 	RoutePathStateChecksum         = "/api/v0/state-checksum"
 
 	// validators.go
-	RoutePathValidators = "/api/v0/validators"
+	RoutePathValidators      = "/api/v0/validators"
+	RoutePathCheckNodeStatus = "/api/v0/check-node-status"
 
 	// stake.go
 	RoutePathStake       = "/api/v0/stake"
@@ -1351,6 +1352,13 @@ func (fes *APIServer) NewRouter() *muxtrace.Router {
 			[]string{"GET"},
 			RoutePathValidators + "/{publicKeyBase58Check:t?BC[1-9A-HJ-NP-Za-km-z]{51,53}}",
 			fes.GetValidatorByPublicKeyBase58Check,
+			PublicAccess,
+		},
+		{
+			"CheckNodeStatus",
+			[]string{"POST", "OPTIONS"},
+			RoutePathCheckNodeStatus,
+			fes.CheckNodeStatus,
 			PublicAccess,
 		},
 		{

--- a/routes/validators.go
+++ b/routes/validators.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"time"
 )
 
 type RegisterAsValidatorRequest struct {
@@ -373,7 +374,7 @@ func (fes *APIServer) CheckNodeStatus(ww http.ResponseWriter, req *http.Request)
 	// We do an *extremely* simple check for now, which is that we just check to see if the node
 	// is reachable at all.
 	// TODO: We should beef this up to test an actual version handshake or something more robust.
-	conn, err := net.Dial("tcp", requestData.NodeHostPort)
+	conn, err := net.DialTimeout("tcp", requestData.NodeHostPort, 5*time.Second)
 	if err != nil {
 		_AddBadRequestError(ww, fmt.Sprintf(
 			"Problem connecting to %v: %v", requestData.NodeHostPort, err))


### PR DESCRIPTION
An endpoint that allows our validator hub to quickly tell you if your node is reachable by other validators.

Curl command to test it, assuming you're running backend on 18001 and a real node on 18000 (eg like we do with n0_test).
```
$ curl 'http://localhost:18001/api/v0/check-node-status'  -H 'content-type: application/json'  --data-raw '{"NodeHostPort":"localhost:18000"}'   --compressed
```

When successful returns:
```
{"Success":true}
```

When not successful returns:
```
{"error":"Problem connecting to dorsey.bitclout.com:18002: dial tcp 35.192.117.201:18002: i/o timeout"}
```
```
{"error":"Problem connecting to localhost:18003: dial tcp 127.0.0.1:18003: connect: connection refused"}
```