### PR TITLE
Add simple balance endpoint (for amm usage)

### DIFF
--- a/routes/server.go
+++ b/routes/server.go
@@ -2427,7 +2427,7 @@ func (fes *APIServer) NewRouter() *muxtrace.Router {
 func CheckPrecedingTransactions(inner http.Handler, precedingTransactionsLimit int) http.Handler {
 	return http.HandlerFunc(func(ww http.ResponseWriter, rr *http.Request) {
 		// If the request is NOT a POST request, skip this middleware as the request has no relevant payload.
-		if rr.Method != "POST" {
+		if rr.Method != "POST" || rr.Header.Get("Content-Type") != "application/json" {
 			inner.ServeHTTP(ww, rr)
 			return
 		}

--- a/routes/server.go
+++ b/routes/server.go
@@ -77,7 +77,7 @@ const (
 	RoutePathGetSingleProfile                           = "/api/v0/get-single-profile"
 	RoutePathGetSingleProfilePicture                    = "/api/v0/get-single-profile-picture"
 	RoutePathGetHodlersForPublicKey                     = "/api/v0/get-hodlers-for-public-key"
-	RoutePathGetBalancesForPublicKey                    = "/api/v0/get-balances-for-public-key"
+	RoutePathGetTokenBalancesForPublicKey               = "/api/v0/get-token-balances-for-public-key"
 	RoutePathGetHodlersCountForPublicKeys               = "/api/v0/get-hodlers-count-for-public-keys"
 	RoutePathGetDiamondsForPublicKey                    = "/api/v0/get-diamonds-for-public-key"
 	RoutePathGetFollowsStateless                        = "/api/v0/get-follows-stateless"
@@ -931,10 +931,10 @@ func (fes *APIServer) NewRouter() *muxtrace.Router {
 			PublicAccess,
 		},
 		{
-			"GetBalancesForPublicKey",
+			"GetTokenBalancesForPublicKey",
 			[]string{"POST", "OPTIONS"},
-			RoutePathGetBalancesForPublicKey,
-			fes.GetBalancesForPublicKey,
+			RoutePathGetTokenBalancesForPublicKey,
+			fes.GetTokenBalancesForPublicKey,
 			PublicAccess,
 		},
 		{

--- a/routes/server.go
+++ b/routes/server.go
@@ -77,6 +77,7 @@ const (
 	RoutePathGetSingleProfile                           = "/api/v0/get-single-profile"
 	RoutePathGetSingleProfilePicture                    = "/api/v0/get-single-profile-picture"
 	RoutePathGetHodlersForPublicKey                     = "/api/v0/get-hodlers-for-public-key"
+	RoutePathGetBalancesForPublicKey                    = "/api/v0/get-balances-for-public-key"
 	RoutePathGetHodlersCountForPublicKeys               = "/api/v0/get-hodlers-count-for-public-keys"
 	RoutePathGetDiamondsForPublicKey                    = "/api/v0/get-diamonds-for-public-key"
 	RoutePathGetFollowsStateless                        = "/api/v0/get-follows-stateless"
@@ -927,6 +928,13 @@ func (fes *APIServer) NewRouter() *muxtrace.Router {
 			[]string{"POST", "OPTIONS"},
 			RoutePathGetHodlersForPublicKey,
 			fes.GetHodlersForPublicKey,
+			PublicAccess,
+		},
+		{
+			"GetBalancesForPublicKey",
+			[]string{"POST", "OPTIONS"},
+			RoutePathGetBalancesForPublicKey,
+			fes.GetBalancesForPublicKey,
 			PublicAccess,
 		},
 		{

--- a/routes/user.go
+++ b/routes/user.go
@@ -1479,6 +1479,119 @@ func (fes *APIServer) GetHodlersForPublicKey(ww http.ResponseWriter, req *http.R
 	}
 }
 
+type GetBalancesForPublicKeyRequest struct {
+	// The public key we're fetching balances for
+	UserPublicKey string `safeForLogging:"true"`
+
+	// A list of public keys of the crators whose coins we want to fetch
+	// the balance of for the user. For DESO,
+	// can specify either "DESO" or the ZeroPkid via base58check encoding.
+	// Either will work.
+	CreatorPublicKeys []string
+
+	// If unset, defaults to TxnStatusInMempool
+	TxnStatus TxnStatus `safeForLogging:"true"`
+}
+
+type SimpleBalanceResponse struct {
+	// The public key of the user whose balance we're fetching
+	UserPublicKeyBase58Check string
+	// The public key of the user whose coin we're fetching the balance of
+	CreatorPublicKeyBase58Check string
+
+	// A base-10 encoded string of the balance in base units, which is internally
+	// represented as a uint256
+	BalanceBaseUnits string
+}
+
+type GetBalancesForPublicKeyResponse struct {
+	Balances map[string]*SimpleBalanceResponse
+}
+
+func (fes *APIServer) GetBalancesForPublicKey(ww http.ResponseWriter, req *http.Request) {
+	decoder := json.NewDecoder(io.LimitReader(req.Body, MaxRequestBodySizeBytes))
+	requestData := GetBalancesForPublicKeyRequest{}
+	if err := decoder.Decode(&requestData); err != nil {
+		_AddBadRequestError(ww, fmt.Sprintf(
+			"GetHodlersForPublicKey: Problem parsing request body: %v", err))
+		return
+	}
+
+	txnStatus := requestData.TxnStatus
+	if txnStatus == "" {
+		txnStatus = TxnStatusInMempool
+	}
+	// Get a view based on the txnStatus
+	utxoView, err := fes.GetUtxoViewGivenTxnStatus(txnStatus)
+	if err != nil {
+		_AddInternalServerError(ww, fmt.Sprintf("GetDAOCoinLimitOrdersById: Problem fetching utxoView: %v", err))
+		return
+	}
+
+	// Decode the public key for which we are fetching balances
+	if requestData.UserPublicKey == "" {
+		_AddBadRequestError(ww, fmt.Sprintf("GetBalancesForPublicKey: Missing UserPublicKey"))
+		return
+	}
+	userPublicKeyBytes, _, err := lib.Base58CheckDecode(requestData.UserPublicKey)
+	if err != nil {
+		_AddBadRequestError(ww, fmt.Sprintf("GetHodlersForPublicKey: Problem decoding user public key: %v", err))
+		return
+	}
+	if len(requestData.CreatorPublicKeys) == 0 {
+		_AddBadRequestError(ww, fmt.Sprintf("GetBalancesForPublicKey: Missing CreatorPublicKeys"))
+		return
+	}
+
+	balancesMap := make(map[string]*SimpleBalanceResponse)
+	for _, creatorPublicKeyStr := range requestData.CreatorPublicKeys {
+		// Deso is a special case
+		if IsDesoPkid(creatorPublicKeyStr) {
+			desoNanos, err := utxoView.GetDeSoBalanceNanosForPublicKey(userPublicKeyBytes)
+			if err != nil {
+				_AddBadRequestError(ww, fmt.Sprintf("GetBalancesForPublicKey: Problem getting balance: %v", err))
+				return
+			}
+			// When we're dealing with DESO, we use whatever identifier they passed
+			// in as the key. This is the most convenient thing to do for the caller.
+			// If we instead always returned DESO as the key then they would have to
+			// accommodate that, which would be annoying.
+			balancesMap[creatorPublicKeyStr] = &SimpleBalanceResponse{
+				UserPublicKeyBase58Check:    requestData.UserPublicKey,
+				CreatorPublicKeyBase58Check: creatorPublicKeyStr,
+				BalanceBaseUnits:            strconv.FormatUint(desoNanos, 10),
+			}
+			continue
+		}
+		creatorPkBytes, _, err := lib.Base58CheckDecode(creatorPublicKeyStr)
+		if err != nil {
+			_AddBadRequestError(ww, fmt.Sprintf("GetHodlersForPublicKey: Problem decoding creator public key: %v", err))
+			return
+		}
+
+		balanceEntry, _, _ := utxoView.GetBalanceEntryForHODLerPubKeyAndCreatorPubKey(
+			userPublicKeyBytes, creatorPkBytes, true)
+		if balanceEntry == nil || balanceEntry.IsDeleted() {
+			balanceEntry = &lib.BalanceEntry{}
+		}
+		// Convert balanceEntry uint256 to string
+		balancesMap[creatorPublicKeyStr] = &SimpleBalanceResponse{
+			UserPublicKeyBase58Check:    requestData.UserPublicKey,
+			CreatorPublicKeyBase58Check: creatorPublicKeyStr,
+			BalanceBaseUnits:            balanceEntry.BalanceNanos.String(),
+		}
+	}
+
+	res := &GetBalancesForPublicKeyResponse{
+		Balances: balancesMap,
+	}
+	if err = json.NewEncoder(ww).Encode(res); err != nil {
+		_AddBadRequestError(ww, fmt.Sprintf(
+			"GetHodlersForPublicKey: Problem encoding response as JSON: %v", err))
+		return
+	}
+}
+
 type GetHolderCountForPublicKeysRequest struct {
 	PublicKeysBase58Check []string
 	IsDAOCoin             bool


### PR DESCRIPTION
There wasn't a clean way to get the balance of a set of coins, which is needed in order to determine if the amm should initialize a market. Added this endpoint to address this need.

There's also a thorough test for it in the amm code here:
https://github.com/deso-protocol/amm-service/blob/f4953a8f1a141110a10f2ced44e7983176d5d46e/ammlib/amm_config_test.go#L1170