### PR TITLE
Update basic_transfer.go - Reject malformed BASIC_TRANSFER without/with invalid amountNanos

### DIFF
--- a/scripts/tools/toolslib/basic_transfer.go
+++ b/scripts/tools/toolslib/basic_transfer.go
@@ -14,6 +14,9 @@ import (
 // _generateUnsignedSendDeSo...
 func _generateUnsignedSendDeSo(senderPubKey *btcec.PublicKey, recipientPubKey *btcec.PublicKey, amountNanos int64,
 	params *lib.DeSoParams, node string) (*routes.SendDeSoResponse, error) {
+	if !amountNanos || amountNanos <= 0 {
+		return nil, errors.New("_generateUnsignedSendDeSo() invalid AmountNanos: must be a positive integer")
+	}
 	endpoint := node + routes.RoutePathSendDeSo
 
 	// Setup request


### PR DESCRIPTION
Reject BASIC_TRANSFER transactions without amountNanos - add validation for valid amountNanos value.