### PR TITLE
Updates to support smoother AMM coin creation in Focus

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,10 @@ type Config struct {
 	// Core
 	APIPort uint16
 
+	// This is the base58-encoded public key for the AMM_METADATA user, which is
+	// used to set the trading fees on users' coins.
+	AmmMetadataPublicKey string
+
 	// Onboarding
 	StarterDESOSeed         string
 	StarterDESONanos        uint64
@@ -113,6 +117,10 @@ func LoadConfig(coreConfig *coreCmd.Config) *Config {
 		// TODO: pull this out of core. we shouldn't need core's config here
 		config.APIPort = coreConfig.Params.DefaultJSONPort
 	}
+
+	// This is the base58-encoded public key for the AMM_METADATA user, which is
+	// used to set the trading fees on users' coins.
+	config.AmmMetadataPublicKey = viper.GetString("amm-metadata-public-key")
 
 	// Onboarding
 	config.StarterDESOSeed = viper.GetString("starter-deso-seed")

--- a/routes/dao_coin_exchange_with_fees.go
+++ b/routes/dao_coin_exchange_with_fees.go
@@ -259,7 +259,8 @@ func (fes *APIServer) UpdateDaoCoinMarketFees(ww http.ResponseWriter, req *http.
 		additionalOutputs,
 	)
 	if err != nil {
-		_AddInternalServerError(ww, fmt.Sprintf("CreateUserAssociation: problem creating txn: %v", err))
+		_AddInternalServerError(ww, fmt.Sprintf("CreateUserAssociation: problem creating user "+
+			"association txn: %v", err))
 		return
 	}
 
@@ -832,6 +833,8 @@ func (fes *APIServer) GetBaseCurrencyPriceEndpoint(ww http.ResponseWriter, req *
 		return
 	}
 
+	// If any of these are too big for the Float64() it's better to best-effort
+	// them rather than error out.
 	baseCurrencyFilledFloat, _ := baseCurrencyFilled.Float64()
 	quoteCurrencyReceivedFloat, _ := quoteCurrencyReceived.Float64()
 	receiveAmountInUsdFloat, _ := big.NewFloat(0).Mul(

--- a/routes/server.go
+++ b/routes/server.go
@@ -72,33 +72,34 @@ const (
 	RoutePathGetSignatureIndex        = "/api/v0/signature-index"
 	RoutePathGetTxnConstructionParams = "/api/v0/txn-construction-params"
 
-	RoutePathGetUsersStateless                          = "/api/v0/get-users-stateless"
-	RoutePathDeleteIdentities                           = "/api/v0/delete-identities"
-	RoutePathGetProfiles                                = "/api/v0/get-profiles"
-	RoutePathGetSingleProfile                           = "/api/v0/get-single-profile"
-	RoutePathGetSingleProfilePicture                    = "/api/v0/get-single-profile-picture"
-	RoutePathGetHodlersForPublicKey                     = "/api/v0/get-hodlers-for-public-key"
-	RoutePathGetTokenBalancesForPublicKey               = "/api/v0/get-token-balances-for-public-key"
-	RoutePathGetHodlersCountForPublicKeys               = "/api/v0/get-hodlers-count-for-public-keys"
-	RoutePathGetDiamondsForPublicKey                    = "/api/v0/get-diamonds-for-public-key"
-	RoutePathGetFollowsStateless                        = "/api/v0/get-follows-stateless"
-	RoutePathGetUserGlobalMetadata                      = "/api/v0/get-user-global-metadata"
-	RoutePathUpdateUserGlobalMetadata                   = "/api/v0/update-user-global-metadata"
-	RoutePathGetNotifications                           = "/api/v0/get-notifications"
-	RoutePathGetUnreadNotificationsCount                = "/api/v0/get-unread-notifications-count"
-	RoutePathSetNotificationMetadata                    = "/api/v0/set-notification-metadata"
-	RoutePathBlockPublicKey                             = "/api/v0/block-public-key"
-	RoutePathIsFollowingPublicKey                       = "/api/v0/is-following-public-key"
-	RoutePathIsHodlingPublicKey                         = "/api/v0/is-hodling-public-key"
-	RoutePathGetUserDerivedKeys                         = "/api/v0/get-user-derived-keys"
-	RoutePathGetSingleDerivedKey                        = "/api/v0/get-single-derived-key"
-	RoutePathGetTransactionSpendingLimitHexString       = "/api/v0/get-transaction-spending-limit-hex-string"
-	RoutePathGetAccessBytes                             = "/api/v0/get-access-bytes"
-	RoutePathGetTransactionSpendingLimitResponseFromHex = "/api/v0/get-transaction-spending-limit-response-from-hex"
-	RoutePathDeletePII                                  = "/api/v0/delete-pii"
-	RoutePathGetUserMetadata                            = "/api/v0/get-user-metadata"
-	RoutePathGetUsernameForPublicKey                    = "/api/v0/get-user-name-for-public-key"
-	RoutePathGetPublicKeyForUsername                    = "/api/v0/get-public-key-for-user-name"
+	RoutePathGetUsersStateless                           = "/api/v0/get-users-stateless"
+	RoutePathDeleteIdentities                            = "/api/v0/delete-identities"
+	RoutePathGetProfiles                                 = "/api/v0/get-profiles"
+	RoutePathGetSingleProfile                            = "/api/v0/get-single-profile"
+	RoutePathGetSingleProfilePicture                     = "/api/v0/get-single-profile-picture"
+	RoutePathGetHodlersForPublicKey                      = "/api/v0/get-hodlers-for-public-key"
+	RoutePathGetGetHoldersForPublicKeyWithLockedBalances = "/api/v0/get-holders-for-public-key-with-locked-balances"
+	RoutePathGetTokenBalancesForPublicKey                = "/api/v0/get-token-balances-for-public-key"
+	RoutePathGetHodlersCountForPublicKeys                = "/api/v0/get-hodlers-count-for-public-keys"
+	RoutePathGetDiamondsForPublicKey                     = "/api/v0/get-diamonds-for-public-key"
+	RoutePathGetFollowsStateless                         = "/api/v0/get-follows-stateless"
+	RoutePathGetUserGlobalMetadata                       = "/api/v0/get-user-global-metadata"
+	RoutePathUpdateUserGlobalMetadata                    = "/api/v0/update-user-global-metadata"
+	RoutePathGetNotifications                            = "/api/v0/get-notifications"
+	RoutePathGetUnreadNotificationsCount                 = "/api/v0/get-unread-notifications-count"
+	RoutePathSetNotificationMetadata                     = "/api/v0/set-notification-metadata"
+	RoutePathBlockPublicKey                              = "/api/v0/block-public-key"
+	RoutePathIsFollowingPublicKey                        = "/api/v0/is-following-public-key"
+	RoutePathIsHodlingPublicKey                          = "/api/v0/is-hodling-public-key"
+	RoutePathGetUserDerivedKeys                          = "/api/v0/get-user-derived-keys"
+	RoutePathGetSingleDerivedKey                         = "/api/v0/get-single-derived-key"
+	RoutePathGetTransactionSpendingLimitHexString        = "/api/v0/get-transaction-spending-limit-hex-string"
+	RoutePathGetAccessBytes                              = "/api/v0/get-access-bytes"
+	RoutePathGetTransactionSpendingLimitResponseFromHex  = "/api/v0/get-transaction-spending-limit-response-from-hex"
+	RoutePathDeletePII                                   = "/api/v0/delete-pii"
+	RoutePathGetUserMetadata                             = "/api/v0/get-user-metadata"
+	RoutePathGetUsernameForPublicKey                     = "/api/v0/get-user-name-for-public-key"
+	RoutePathGetPublicKeyForUsername                     = "/api/v0/get-public-key-for-user-name"
 
 	// dao_coin_exchange.go
 	RoutePathGetDaoCoinLimitOrders           = "/api/v0/get-dao-coin-limit-orders"
@@ -948,6 +949,13 @@ func (fes *APIServer) NewRouter() *muxtrace.Router {
 			[]string{"POST", "OPTIONS"},
 			RoutePathGetHodlersForPublicKey,
 			fes.GetHodlersForPublicKey,
+			PublicAccess,
+		},
+		{
+			"GetHoldersForPublicKeyWithLockedBalances",
+			[]string{"POST", "OPTIONS"},
+			RoutePathGetGetHoldersForPublicKeyWithLockedBalances,
+			fes.GetHoldersForPublicKeyWithLockedBalances,
 			PublicAccess,
 		},
 		{

--- a/routes/shared.go
+++ b/routes/shared.go
@@ -212,6 +212,15 @@ type User struct {
 	MustCompleteTutorial bool
 }
 
+// Create a new type of BalanceEntryResponse so we don't break any existing
+// code that relies on the old version.
+type ExtendedBalanceEntryResponse struct {
+	UnlockedBalanceEntry *BalanceEntryResponse
+
+	LockedBalanceEntrys    []*LockedBalanceEntryResponse
+	LockedBalanceBaseUnits *uint256.Int
+}
+
 type BalanceEntryResponse struct {
 	// The public keys are provided for the frontend
 	HODLerPublicKeyBase58Check string

--- a/routes/transaction.go
+++ b/routes/transaction.go
@@ -89,7 +89,7 @@ func (fes *APIServer) GetTxn(ww http.ResponseWriter, req *http.Request) {
 	// committed tip height. Otherwise we'll be missing ~2 blocks in limbo.
 	coreChainTipHeight := fes.TXIndex.CoreChain.BlockTip().Height
 	for fes.TXIndex.TXIndexChain.BlockTip().Height < coreChainTipHeight {
-		if time.Since(startTime) > 90*time.Second {
+		if time.Since(startTime) > 30*time.Second {
 			_AddBadRequestError(ww, fmt.Sprintf("GetTxn: Timed out waiting for txindex to sync."))
 			return
 		}

--- a/routes/transaction.go
+++ b/routes/transaction.go
@@ -89,7 +89,7 @@ func (fes *APIServer) GetTxn(ww http.ResponseWriter, req *http.Request) {
 	// committed tip height. Otherwise we'll be missing ~2 blocks in limbo.
 	coreChainTipHeight := fes.TXIndex.CoreChain.BlockTip().Height
 	for fes.TXIndex.TXIndexChain.BlockTip().Height < coreChainTipHeight {
-		if time.Since(startTime) > 30*time.Second {
+		if time.Since(startTime) > 90*time.Second {
 			_AddBadRequestError(ww, fmt.Sprintf("GetTxn: Timed out waiting for txindex to sync."))
 			return
 		}

--- a/routes/user.go
+++ b/routes/user.go
@@ -410,7 +410,8 @@ func (fes *APIServer) GetHodlingsForPublicKey(
 func (fes *APIServer) GetHodlYouMap(pkid *lib.PKIDEntry, fetchProfiles bool, isDAOCoin bool, utxoView *lib.UtxoView) (
 	_youHodlMap map[string]*BalanceEntryResponse, _err error) {
 	// Get all the hodlings for this user from the db
-	entriesHodlingYou, profileHodlingYou, err := utxoView.GetHolders(pkid.PKID, fetchProfiles, isDAOCoin)
+	entriesHodlingYou, profileHodlingYou, _, _, err := utxoView.GetHolders(
+		pkid.PKID, fetchProfiles, isDAOCoin)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"GetHodlingsForPublicKey: Error looking up balance entries in db: %v", err)
@@ -1601,7 +1602,7 @@ func (fes *APIServer) GetHodlersCountForPublicKeys(ww http.ResponseWriter, req *
 		}
 		// Get PKID and then get holders for PKID
 		pkid := utxoView.GetPKIDForPublicKey(pkBytes)
-		balanceEntries, _, err := utxoView.GetHolders(pkid.PKID, false, requestData.IsDAOCoin)
+		balanceEntries, _, _, _, err := utxoView.GetHolders(pkid.PKID, false, requestData.IsDAOCoin)
 		if err != nil {
 			_AddInternalServerError(
 				ww,
@@ -3774,4 +3775,135 @@ func (fes *APIServer) GetProfileEntryResponseForPublicKeyBytes(publicKeyBytes []
 		profileEntryResponse = fes._profileEntryToResponse(profileEntry, utxoView)
 	}
 	return profileEntryResponse
+}
+
+type GetHoldersForPublicKeyWithLockedBalancesRequest struct {
+	// Either PublicKeyBase58Check or Username can be set by the client to specify
+	// which user we're obtaining posts for
+	// If both are specified, PublicKeyBase58Check will supercede
+	PublicKeyBase58Check string `safeForLogging:"true"`
+	Username             string `safeForLogging:"true"`
+}
+
+type GetHoldersForPublicKeyWithLockedBalancesResponse struct {
+	Holders map[string]*ExtendedBalanceEntryResponse
+}
+
+func (fes *APIServer) GetHoldersForPublicKeyWithLockedBalances(ww http.ResponseWriter, req *http.Request) {
+	decoder := json.NewDecoder(io.LimitReader(req.Body, MaxRequestBodySizeBytes))
+	requestData := GetHoldersForPublicKeyWithLockedBalancesRequest{}
+	if err := decoder.Decode(&requestData); err != nil {
+		_AddBadRequestError(ww, fmt.Sprintf(
+			"GetHoldersForPublicKeyWithLockedBalances: Problem parsing request body: %v", err))
+		return
+	}
+
+	// Get a view
+	utxoView, err := fes.backendServer.GetMempool().GetAugmentedUniversalView()
+	if err != nil {
+		_AddBadRequestError(ww, fmt.Sprintf("GetHoldersForPublicKeyWithLockedBalances: Error getting utxoView: %v", err))
+		return
+	}
+
+	// Decode the public key for which we are fetching hodlers / hodlings.  If public key is not provided, use username
+	var creatorPublicKeyBytes []byte
+	if requestData.PublicKeyBase58Check != "" {
+		creatorPublicKeyBytes, _, err = lib.Base58CheckDecode(requestData.PublicKeyBase58Check)
+		if err != nil {
+			_AddBadRequestError(ww, fmt.Sprintf("GetHoldersForPublicKeyWithLockedBalances: Problem decoding user public key: %v", err))
+			return
+		}
+	} else {
+		username := requestData.Username
+		profileEntry := utxoView.GetProfileEntryForUsername([]byte(username))
+
+		// Return an error if we failed to find a profile entry
+		if profileEntry == nil {
+			_AddNotFoundError(ww, fmt.Sprintf("GetHoldersForPublicKeyWithLockedBalances: could not find profile for username: %v", username))
+			return
+		}
+		creatorPublicKeyBytes = profileEntry.PublicKey
+	}
+
+	unlockedBalanceEntrys, _, lockedBalanceEntryMap, _, err := utxoView.GetHolders(
+		utxoView.GetPKIDForPublicKey(creatorPublicKeyBytes).PKID, false, true)
+
+	holdersMap := make(map[string]*ExtendedBalanceEntryResponse)
+	for _, unlockedEntry := range unlockedBalanceEntrys {
+		holderPublicKeyBytes := utxoView.GetPublicKeyForPKID(unlockedEntry.HODLerPKID)
+		holderPublicKeyStr := lib.PkToString(holderPublicKeyBytes, fes.Params)
+		unlockedBalanceEntryResponse := fes._balanceEntryToResponse(
+			unlockedEntry, 0, nil, utxoView)
+		prevBalance := holdersMap[holderPublicKeyStr]
+		if prevBalance == nil {
+			prevBalance = &ExtendedBalanceEntryResponse{
+				UnlockedBalanceEntry: unlockedBalanceEntryResponse,
+
+				LockedBalanceEntrys:    []*LockedBalanceEntryResponse{},
+				LockedBalanceBaseUnits: uint256.NewInt(),
+			}
+		} else {
+			// Error. We shouldn't have any duplicates in this list ever
+			_AddBadRequestError(ww, fmt.Sprintf(
+				"GetHoldersForPublicKeyWithLockedBalances: Duplicate "+
+					"unlocked balance entry for public key: %v", holderPublicKeyStr))
+			return
+		}
+		holdersMap[holderPublicKeyStr] = prevBalance
+	}
+
+	for pkid, lockedBalanceEntrys := range lockedBalanceEntryMap {
+		publicKeyBytes := utxoView.GetPublicKeyForPKID(&pkid)
+		publicKeyStr := lib.PkToString(publicKeyBytes, fes.Params)
+		prevBalance := holdersMap[publicKeyStr]
+
+		lockedBalResponses := []*LockedBalanceEntryResponse{}
+		totalBalanceBaseUnits := uint256.NewInt()
+		for _, lockedBalanceEntry := range lockedBalanceEntrys {
+			lockedBalResponses = append(lockedBalResponses, fes._lockedBalanceEntryToResponse(
+				lockedBalanceEntry, utxoView, fes.Params))
+			totalBalanceBaseUnits = uint256.NewInt().Add(
+				totalBalanceBaseUnits, &lockedBalanceEntry.BalanceBaseUnits)
+		}
+
+		if prevBalance == nil {
+			// If there's no unlocked balance for this key, we need to create the
+			// entry from scratch.
+			unlockedBalanceEntryResponse := fes._balanceEntryToResponse(
+				&lib.BalanceEntry{
+					HODLerPKID:   &pkid,
+					CreatorPKID:  utxoView.GetPKIDForPublicKey(creatorPublicKeyBytes).PKID,
+					BalanceNanos: *uint256.NewInt(),
+					HasPurchased: false,
+				}, 0, nil, utxoView)
+
+			prevBalance = &ExtendedBalanceEntryResponse{
+				UnlockedBalanceEntry:   unlockedBalanceEntryResponse,
+				LockedBalanceEntrys:    lockedBalResponses,
+				LockedBalanceBaseUnits: totalBalanceBaseUnits,
+			}
+		} else {
+			// If this pkid already had an unlocked balance, we need to augment
+			// the existing entry rather than creating a new one.
+			if len(prevBalance.LockedBalanceEntrys) > 0 {
+				_AddBadRequestError(ww, fmt.Sprintf(
+					"GetHoldersForPublicKeyWithLockedBalances: Duplicate "+
+						"locked balance entry for public key: %v", publicKeyStr))
+				return
+			}
+			prevBalance.LockedBalanceEntrys = lockedBalResponses
+			prevBalance.LockedBalanceBaseUnits = totalBalanceBaseUnits
+		}
+
+		holdersMap[publicKeyStr] = prevBalance
+	}
+
+	res := &GetHoldersForPublicKeyWithLockedBalancesResponse{
+		Holders: holdersMap,
+	}
+	if err = json.NewEncoder(ww).Encode(res); err != nil {
+		_AddBadRequestError(ww, fmt.Sprintf(
+			"GetHoldersForPublicKeyWithLockedBalances: Problem encoding response as JSON: %v", err))
+		return
+	}
 }


### PR DESCRIPTION
- Add AmmMetadataPublicKey as an optional backend flag. This flag is required to be set if you want to SET or GET trading fees for DaoCoinLimitOrderWithFee.
- Updated trading fees to be an association set by the AmmMetadataPublicKey rather than by the individual user. This allows users to credibly disable trading fee updates. Tests are in the amm-service repo and all are passing.
- Fixed a bunch of issues related to using DESO as the quote currency in a DaoCoinLimitOrderWithFees transaction. Thorough and updated tests are in the amm-service repo and all tests are passing there.
- Added a new backend endpoint to get all holders of a coin WITH locked balances as well. This was needed in order to support lockup-based features when creating a coin, without having to add a dependency on GraphQL (because the amm-service currenly has no deps on GraphQL).