### PR TITLE
Use coinbase price for DESO in dao-coin-limit-order

### DIFF
--- a/routes/dao_coin_exchange_with_fees.go
+++ b/routes/dao_coin_exchange_with_fees.go
@@ -909,7 +909,7 @@ func (fes *APIServer) GetQuoteCurrencyPriceInUsd(
 		// in order to minimize discrepancies with other sources.
 		desoUsdCents := fes.MostRecentCoinbasePriceUSDCents
 		if desoUsdCents == 0 {
-			return "", "", "", fmt.Errorf("GetQuoteCurrencyPriceInUsd: Coinbase price is zero")
+			return "", "", "", fmt.Errorf("GetQuoteCurrencyPriceInUsd: Coinbase DESO price is zero")
 		}
 		price := fmt.Sprintf("%0.9f", float64(desoUsdCents)/100)
 		return price, price, price, nil // TODO: get real bid and ask prices.
@@ -947,7 +947,7 @@ func (fes *APIServer) GetQuoteCurrencyPriceInUsd(
 		// in order to minimize discrepancies with other sources.
 		desoUsdCents := fes.MostRecentCoinbasePriceUSDCents
 		if desoUsdCents == 0 {
-			return "", "", "", fmt.Errorf("GetQuoteCurrencyPriceInUsd: Coinbase price is zero")
+			return "", "", "", fmt.Errorf("GetQuoteCurrencyPriceInUsd: Coinbase DESO price is zero")
 		}
 		pkid := utxoView.GetPKIDForPublicKey(pkBytes)
 		if pkid == nil {

--- a/routes/dao_coin_exchange_with_fees.go
+++ b/routes/dao_coin_exchange_with_fees.go
@@ -904,7 +904,10 @@ func (fes *APIServer) GetQuoteCurrencyPriceInUsdEndpoint(ww http.ResponseWriter,
 func (fes *APIServer) GetQuoteCurrencyPriceInUsd(
 	quoteCurrencyPublicKey string) (_midmarket string, _bid string, _ask string, _err error) {
 	if IsDesoPkid(quoteCurrencyPublicKey) {
-		desoUsdCents := fes.GetExchangeDeSoPrice()
+		// TODO: We're taking the Coinbase price directly here, but ideally we would get it from
+		// a function that abstracts away the exchange we're getting it from. We do this for now
+		// in order to minimize discrepancies with other sources.
+		desoUsdCents := fes.MostRecentCoinbasePriceUSDCents
 		price := fmt.Sprintf("%0.9f", float64(desoUsdCents)/100)
 		return price, price, price, nil // TODO: get real bid and ask prices.
 	}
@@ -936,7 +939,7 @@ func (fes *APIServer) GetQuoteCurrencyPriceInUsd(
 	} else if lowerUsername == "focus" ||
 		lowerUsername == "openfund" {
 
-		desoUsdCents := fes.GetExchangeDeSoPrice()
+		desoUsdCents := fes.MostRecentCoinbasePriceUSDCents
 		pkid := utxoView.GetPKIDForPublicKey(pkBytes)
 		if pkid == nil {
 			return "", "", "", fmt.Errorf("GetQuoteCurrencyPriceInUsd: Error getting pkid for public key %v",

--- a/routes/dao_coin_exchange_with_fees.go
+++ b/routes/dao_coin_exchange_with_fees.go
@@ -939,6 +939,9 @@ func (fes *APIServer) GetQuoteCurrencyPriceInUsd(
 	} else if lowerUsername == "focus" ||
 		lowerUsername == "openfund" {
 
+		// TODO: We're taking the Coinbase price directly here, but ideally we would get it from
+		// a function that abstracts away the exchange we're getting it from. We do this for now
+		// in order to minimize discrepancies with other sources.
 		desoUsdCents := fes.MostRecentCoinbasePriceUSDCents
 		pkid := utxoView.GetPKIDForPublicKey(pkBytes)
 		if pkid == nil {

--- a/routes/dao_coin_exchange_with_fees.go
+++ b/routes/dao_coin_exchange_with_fees.go
@@ -908,6 +908,9 @@ func (fes *APIServer) GetQuoteCurrencyPriceInUsd(
 		// a function that abstracts away the exchange we're getting it from. We do this for now
 		// in order to minimize discrepancies with other sources.
 		desoUsdCents := fes.MostRecentCoinbasePriceUSDCents
+		if desoUsdCents == 0 {
+			return "", "", "", fmt.Errorf("GetQuoteCurrencyPriceInUsd: Coinbase price is zero")
+		}
 		price := fmt.Sprintf("%0.9f", float64(desoUsdCents)/100)
 		return price, price, price, nil // TODO: get real bid and ask prices.
 	}
@@ -943,6 +946,9 @@ func (fes *APIServer) GetQuoteCurrencyPriceInUsd(
 		// a function that abstracts away the exchange we're getting it from. We do this for now
 		// in order to minimize discrepancies with other sources.
 		desoUsdCents := fes.MostRecentCoinbasePriceUSDCents
+		if desoUsdCents == 0 {
+			return "", "", "", fmt.Errorf("GetQuoteCurrencyPriceInUsd: Coinbase price is zero")
+		}
 		pkid := utxoView.GetPKIDForPublicKey(pkBytes)
 		if pkid == nil {
 			return "", "", "", fmt.Errorf("GetQuoteCurrencyPriceInUsd: Error getting pkid for public key %v",

--- a/routes/transaction.go
+++ b/routes/transaction.go
@@ -1189,6 +1189,9 @@ func (fes *APIServer) GetNanosFromETH(eth *big.Float, feeBasisPoints uint64) uin
 // GetNanosFromUSDCents - convert USD cents to DeSo nanos
 func (fes *APIServer) GetNanosFromUSDCents(usdCents float64, feeBasisPoints uint64) uint64 {
 	// Get Exchange Price gets the max of price from blockchain.com and the reserve price.
+	// TODO: This function isn't using the Coinbase price. We should make it consistent with other
+	// places that use the Coinbase price, but it's fine for now because the places that call this
+	// function are deprecated.
 	usdCentsPerDeSo := fes.GetExchangeDeSoPrice()
 	conversionRateAfterFee := float64(usdCentsPerDeSo) * (1 + (float64(feeBasisPoints) / (100.0 * 100.0)))
 	nanosPurchased := uint64(usdCents * float64(lib.NanosPerUnit) / conversionRateAfterFee)


### PR DESCRIPTION
- Reproduced the limit order issue reported by @lazynina locally
- Tested and verified that this code fully fixes it
- Searched for all the places we were using a non-coinbase price. Found one and left a comment but didn't change it
- Also fixed and merged in amm-service